### PR TITLE
Add standalone prune script with full prune.py functionality

### DIFF
--- a/prune/standalone_prune.py
+++ b/prune/standalone_prune.py
@@ -776,6 +776,9 @@ def main():
         log.error("  Make sure DATABASE_URL environment variable is set correctly")
         return 1
 
+    # Initialize prune lock system
+    PruneLock.init(Path(CACHE_DIR))
+
     # Create prune configuration
     form_data = create_prune_form(args)
 


### PR DESCRIPTION
Problem:
- CLI mode was failing with "RuntimeError: PruneLock not initialized"
- Interactive mode worked correctly because it called PruneLock.init()
- standalone_prune.py was missing the initialization call

Solution:
- Added PruneLock.init(Path(CACHE_DIR)) in main() after database check
- This matches the pattern used in prune_cli_interactive.py (line 100)
- Ensures lock system is ready before run_prune() calls PruneLock.acquire()

Testing:
- Confirmed fix matches working interactive mode implementation
- PruneLock.init() must be called before any PruneLock.acquire() calls

Fixes issue reported by @Cany where CLI prune commands with --dry-run failed in PostgreSQL cluster environments.