### PR TITLE
fix: fix aiohttp session leak in ollama router

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -124,6 +124,8 @@ async def send_post_request(
 ):
 
     r = None
+    session = None
+    streaming = False
     try:
         session = aiohttp.ClientSession(
             trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
@@ -168,6 +170,7 @@ async def send_post_request(
             if content_type:
                 response_headers["Content-Type"] = content_type
 
+            streaming = True
             return StreamingResponse(
                 r.content,
                 status_code=r.status,
@@ -190,7 +193,7 @@ async def send_post_request(
             detail=detail if e else "Open WebUI: Server Connection Error",
         )
     finally:
-        if not stream:
+        if not streaming:
             await cleanup_response(r, session)
 
 


### PR DESCRIPTION
The send_post_request function was leaking aiohttp sessions when exceptions occurred with stream=True (the default). The `finally` block checked `if not stream:` (the parameter) instead of tracking whether a StreamingResponse was actually returned.

Changes:
- Initialize `session = None` to avoid potential UnboundLocalError
- Add `streaming = False` variable to track actual streaming behavior
- Set `streaming = True` before returning StreamingResponse
- Check `if not streaming:` in finally block instead of `if not stream:`

This ensures sessions are properly closed when exceptions occur before a StreamingResponse can be returned.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
