### PR TITLE
fix: preserve image data when loading messages from DB

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1924,6 +1924,8 @@ def load_messages_from_db(
     """
     Load the message chain from DB up to message_id,
     keeping only LLM-relevant fields (role, content, output).
+    Also preserves image files as image_url content parts so that
+    vision-capable models receive the attached images.
     """
     messages_map = Chats.get_messages_map_by_chat_id(chat_id)
     if not messages_map:
@@ -1933,10 +1935,39 @@ def load_messages_from_db(
     if not db_messages:
         return None
 
-    return [
-        {k: v for k, v in msg.items() if k in ("role", "content", "output")}
-        for msg in db_messages
-    ]
+    result = []
+    for msg in db_messages:
+        clean = {k: v for k, v in msg.items() if k in ("role", "content", "output")}
+
+        # Reconstruct image_url content parts from attached image files.
+        # The frontend builds these from message.files at request time, but
+        # since we replace the frontend messages with DB messages, we need
+        # to rebuild them here.
+        if clean.get("role") == "user" and msg.get("files"):
+            image_files = [
+                f
+                for f in msg["files"]
+                if f.get("type") == "image"
+                or (f.get("content_type") or "").startswith("image/")
+            ]
+            if image_files:
+                content = clean.get("content", "") or ""
+                # Build multipart content with text + image_url parts
+                clean["content"] = [
+                    {"type": "text", "text": content if isinstance(content, str) else ""},
+                    *[
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f.get("url", "")},
+                        }
+                        for f in image_files
+                        if f.get("url")
+                    ],
+                ]
+
+        result.append(clean)
+
+    return result
 
 
 def process_messages_with_output(messages: list[dict]) -> list[dict]:


### PR DESCRIPTION
The load_messages_from_db function (introduced in f2aca78) replaces frontend-constructed messages with DB messages for tool call handling, but only keeps role/content/output fields, dropping the files array.

The frontend builds image_url content parts from message.files at request time. Since the DB stores content as plain text (not multipart arrays with image_url items), replacing messages causes all image data to be silently lost. Vision-capable models then receive no images.

Fix: reconstruct image_url content parts from the message's files array when loading from DB, matching the frontend's behavior.

Fixes #21477, #21457

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
