### PR TITLE
refac: Re-normalize chat tags into chat_tag association table

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -283,11 +283,11 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
             yield session
 
 
-async def insert_ignore_conflict(
-    db: AsyncSession, model, values: dict, conflict_cols: list[str]
+async def insert_on_conflict_nothing(
+    db: AsyncSession, model, values: dict, index_elements: list[str]
 ):
-    """INSERT ... ON CONFLICT (conflict_cols) DO NOTHING against *model* on
-    postgresql or sqlite."""
+    """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING against
+    *model* on postgresql or sqlite. Caller is responsible for committing."""
     bind = await db.connection()
     dialect = bind.dialect.name
     if dialect == 'postgresql':
@@ -296,6 +296,6 @@ async def insert_ignore_conflict(
         stmt = sqlite.insert(model).values(**values)
     else:
         raise NotImplementedError(
-            f'insert_ignore_conflict: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+            f'insert_on_conflict_nothing: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
         )
-    await db.execute(stmt.on_conflict_do_nothing(index_elements=conflict_cols))
+    await db.execute(stmt.on_conflict_do_nothing(index_elements=index_elements))

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -19,6 +19,7 @@ from open_webui.env import (
 )
 from peewee_migrate import Router
 from sqlalchemy import Dialect, create_engine, MetaData, event, types
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker, Session
@@ -285,13 +286,8 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
 async def insert_ignore_conflict(
     db: AsyncSession, model, values: dict, conflict_cols: list[str]
 ):
-    """Execute INSERT ... ON CONFLICT (conflict_cols) DO NOTHING against *model*.
-
-    Dialect-specific because SQLAlchemy's core Insert doesn't expose ON CONFLICT
-    portably; we support postgresql and sqlite.
-    """
-    from sqlalchemy.dialects import postgresql, sqlite
-
+    """INSERT ... ON CONFLICT (conflict_cols) DO NOTHING against *model* on
+    postgresql or sqlite."""
     bind = await db.connection()
     dialect = bind.dialect.name
     if dialect == 'postgresql':
@@ -299,5 +295,7 @@ async def insert_ignore_conflict(
     elif dialect == 'sqlite':
         stmt = sqlite.insert(model).values(**values)
     else:
-        raise NotImplementedError(f'insert_ignore_conflict: unsupported dialect {dialect!r}')
+        raise NotImplementedError(
+            f'insert_ignore_conflict: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+        )
     await db.execute(stmt.on_conflict_do_nothing(index_elements=conflict_cols))

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -309,9 +309,10 @@ async def insert_on_conflict_nothing(
     )
 
 
-# Postgres caps a statement at 65,535 bind params; 5000 rows x ~4 cols stays
-# well under even for the widest tables.
-_INSERT_BATCH_ROWS = 5000
+# Conservative ceiling under Postgres' 65,535 bind-param per-statement limit.
+# Safe for both bulk INSERT (5000 rows x ~4 cols = 20k binds) and IN-predicate
+# chunking (1 bind per value, huge margin).
+SQL_PARAM_BATCH = 5000
 
 
 async def insert_all_on_conflict_nothing(
@@ -325,8 +326,8 @@ async def insert_all_on_conflict_nothing(
     if not values_list:
         return
     insert = _insert_factory_for_dialect(db.bind.dialect.name)
-    for start in range(0, len(values_list), _INSERT_BATCH_ROWS):
-        batch = values_list[start:start + _INSERT_BATCH_ROWS]
+    for start in range(0, len(values_list), SQL_PARAM_BATCH):
+        batch = values_list[start:start + SQL_PARAM_BATCH]
         await db.execute(
             insert(target).values(batch).on_conflict_do_nothing(index_elements=index_elements)
         )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -284,16 +284,17 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
 
 
 async def insert_on_conflict_nothing(
-    db: AsyncSession, model, values: dict, index_elements: list[str]
+    db: AsyncSession, target, values: dict, index_elements: list[str]
 ):
     """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING against
-    *model* on postgresql or sqlite. Caller is responsible for committing."""
+    *target* (mapped ORM class or sa.Table) on postgresql or sqlite. Caller
+    is responsible for committing."""
     bind = await db.connection()
     dialect = bind.dialect.name
     if dialect == 'postgresql':
-        stmt = postgresql.insert(model).values(**values)
+        stmt = postgresql.insert(target).values(**values)
     elif dialect == 'sqlite':
-        stmt = sqlite.insert(model).values(**values)
+        stmt = sqlite.insert(target).values(**values)
     else:
         raise NotImplementedError(
             f'insert_on_conflict_nothing: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -300,7 +300,14 @@ _SQLITE_MAX_BIND_PARAMS = 900
 
 def sql_param_batch(dialect_name: str, cols_per_row: int = 1) -> int:
     cols_per_row = max(1, cols_per_row)
-    budget = _SQLITE_MAX_BIND_PARAMS if dialect_name == 'sqlite' else _PG_MAX_BIND_PARAMS
+    if dialect_name == 'postgresql':
+        budget = _PG_MAX_BIND_PARAMS
+    elif dialect_name == 'sqlite':
+        budget = _SQLITE_MAX_BIND_PARAMS
+    else:
+        raise NotImplementedError(
+            f'sql_param_batch: unsupported dialect {dialect_name!r}; only postgresql and sqlite are supported'
+        )
     return max(1, budget // cols_per_row)
 
 
@@ -330,7 +337,8 @@ async def insert_all_on_conflict_nothing(
         return
     dialect_name = db.get_bind().dialect.name
     insert = _insert_for_dialect(dialect_name)
-    batch_size = sql_param_batch(dialect_name, cols_per_row=len(values_list[0]))
+    # Max width across all dicts, so a heterogeneous batch can't overshoot.
+    batch_size = sql_param_batch(dialect_name, cols_per_row=max(len(v) for v in values_list))
     for start in range(0, len(values_list), batch_size):
         batch = values_list[start:start + batch_size]
         await db.execute(

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -293,28 +293,34 @@ def _insert_factory_for_dialect(dialect_name: str):
     )
 
 
+# db.bind is the engine; read the dialect off it directly so we don't have
+# to check out a connection for every insert helper call.
 async def insert_on_conflict_nothing(
-    db: AsyncSession, target, values: dict, index_elements: list[str]
+    db: AsyncSession,
+    target: 'type[Base] | types.TableClause',
+    values: dict,
+    index_elements: list[str],
 ):
     """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING against
     *target* (mapped ORM class or sa.Table) on postgresql or sqlite. Caller
     is responsible for committing."""
-    bind = await db.connection()
-    insert = _insert_factory_for_dialect(bind.dialect.name)
+    insert = _insert_factory_for_dialect(db.bind.dialect.name)
     await db.execute(
         insert(target).values(**values).on_conflict_do_nothing(index_elements=index_elements)
     )
 
 
 async def insert_all_on_conflict_nothing(
-    db: AsyncSession, target, values_list: list[dict], index_elements: list[str]
+    db: AsyncSession,
+    target: 'type[Base] | types.TableClause',
+    values_list: list[dict],
+    index_elements: list[str],
 ):
     """Bulk INSERT ... ON CONFLICT (index_elements) DO NOTHING on postgresql or
     sqlite. Caller is responsible for committing."""
     if not values_list:
         return
-    bind = await db.connection()
-    insert = _insert_factory_for_dialect(bind.dialect.name)
+    insert = _insert_factory_for_dialect(db.bind.dialect.name)
     await db.execute(
         insert(target).values(values_list).on_conflict_do_nothing(index_elements=index_elements)
     )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -283,7 +283,7 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
             yield session
 
 
-def _insert_factory_for_dialect(dialect_name: str):
+def _insert_for_dialect(dialect_name: str):
     if dialect_name == 'postgresql':
         return postgresql.insert
     if dialect_name == 'sqlite':
@@ -293,8 +293,14 @@ def _insert_factory_for_dialect(dialect_name: str):
     )
 
 
-# db.bind is the engine; read the dialect off it directly so we don't have
-# to check out a connection for every insert helper call.
+# Per-statement row cap, sized to stay under each dialect's bind-parameter
+# ceiling. Postgres allows 65,535; SQLite < 3.32 (May 2020) caps at 999.
+# Used by bulk INSERTs and IN-predicate chunking alike.
+def sql_param_batch(dialect_name: str) -> int:
+    # 200 rows x 4 cols = 800 binds, under SQLite's 999 floor.
+    return 200 if dialect_name == 'sqlite' else 5000
+
+
 async def insert_on_conflict_nothing(
     db: AsyncSession,
     target,  # mapped ORM class or sa.Table
@@ -303,16 +309,10 @@ async def insert_on_conflict_nothing(
 ):
     """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING on
     postgresql or sqlite. Caller is responsible for committing."""
-    insert = _insert_factory_for_dialect(db.bind.dialect.name)
+    insert = _insert_for_dialect(db.get_bind().dialect.name)
     await db.execute(
         insert(target).values(**values).on_conflict_do_nothing(index_elements=index_elements)
     )
-
-
-# Conservative ceiling under Postgres' 65,535 bind-param per-statement limit.
-# Safe for both bulk INSERT (5000 rows x ~4 cols = 20k binds) and IN-predicate
-# chunking (1 bind per value, huge margin).
-SQL_PARAM_BATCH = 5000
 
 
 async def insert_all_on_conflict_nothing(
@@ -325,9 +325,11 @@ async def insert_all_on_conflict_nothing(
     or sqlite. Caller is responsible for committing."""
     if not values_list:
         return
-    insert = _insert_factory_for_dialect(db.bind.dialect.name)
-    for start in range(0, len(values_list), SQL_PARAM_BATCH):
-        batch = values_list[start:start + SQL_PARAM_BATCH]
+    dialect_name = db.get_bind().dialect.name
+    insert = _insert_for_dialect(dialect_name)
+    batch_size = sql_param_batch(dialect_name)
+    for start in range(0, len(values_list), batch_size):
+        batch = values_list[start:start + batch_size]
         await db.execute(
             insert(target).values(batch).on_conflict_do_nothing(index_elements=index_elements)
         )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -293,12 +293,17 @@ def _insert_for_dialect(dialect_name: str):
     )
 
 
-# Per-statement row cap, sized to stay under each dialect's bind-parameter
-# ceiling. Postgres allows 65,535; SQLite < 3.32 (May 2020) caps at 999.
-# Used by bulk INSERTs and IN-predicate chunking alike.
-def sql_param_batch(dialect_name: str) -> int:
-    # 200 rows x 4 cols = 800 binds, under SQLite's 999 floor.
-    return 200 if dialect_name == 'sqlite' else 5000
+# Per-statement bind-parameter budget. Postgres allows 65,535; SQLite < 3.32
+# (May 2020) caps at 999. Callers pass their row width to get a safe row
+# batch size. For single-column IN predicates, pass cols_per_row=1.
+_PG_MAX_BIND_PARAMS = 65_000
+_SQLITE_MAX_BIND_PARAMS = 900
+
+
+def sql_param_batch(dialect_name: str, cols_per_row: int = 1) -> int:
+    cols_per_row = max(1, cols_per_row)
+    budget = _SQLITE_MAX_BIND_PARAMS if dialect_name == 'sqlite' else _PG_MAX_BIND_PARAMS
+    return max(1, budget // cols_per_row)
 
 
 async def insert_on_conflict_nothing(
@@ -327,7 +332,7 @@ async def insert_all_on_conflict_nothing(
         return
     dialect_name = db.get_bind().dialect.name
     insert = _insert_for_dialect(dialect_name)
-    batch_size = sql_param_batch(dialect_name)
+    batch_size = sql_param_batch(dialect_name, cols_per_row=len(values_list[0]))
     for start in range(0, len(values_list), batch_size):
         batch = values_list[start:start + batch_size]
         await db.execute(

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -309,6 +309,11 @@ async def insert_on_conflict_nothing(
     )
 
 
+# Postgres caps a statement at 65,535 bind params; 5000 rows x ~4 cols stays
+# well under even for the widest tables.
+_INSERT_BATCH_ROWS = 5000
+
+
 async def insert_all_on_conflict_nothing(
     db: AsyncSession,
     target,  # mapped ORM class or sa.Table
@@ -320,6 +325,8 @@ async def insert_all_on_conflict_nothing(
     if not values_list:
         return
     insert = _insert_factory_for_dialect(db.bind.dialect.name)
-    await db.execute(
-        insert(target).values(values_list).on_conflict_do_nothing(index_elements=index_elements)
-    )
+    for start in range(0, len(values_list), _INSERT_BATCH_ROWS):
+        batch = values_list[start:start + _INSERT_BATCH_ROWS]
+        await db.execute(
+            insert(target).values(batch).on_conflict_do_nothing(index_elements=index_elements)
+        )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -297,13 +297,12 @@ def _insert_factory_for_dialect(dialect_name: str):
 # to check out a connection for every insert helper call.
 async def insert_on_conflict_nothing(
     db: AsyncSession,
-    target: 'type[Base] | types.TableClause',
+    target,  # mapped ORM class or sa.Table
     values: dict,
     index_elements: list[str],
 ):
-    """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING against
-    *target* (mapped ORM class or sa.Table) on postgresql or sqlite. Caller
-    is responsible for committing."""
+    """Single-row INSERT ... ON CONFLICT (index_elements) DO NOTHING on
+    postgresql or sqlite. Caller is responsible for committing."""
     insert = _insert_factory_for_dialect(db.bind.dialect.name)
     await db.execute(
         insert(target).values(**values).on_conflict_do_nothing(index_elements=index_elements)
@@ -312,12 +311,12 @@ async def insert_on_conflict_nothing(
 
 async def insert_all_on_conflict_nothing(
     db: AsyncSession,
-    target: 'type[Base] | types.TableClause',
+    target,  # mapped ORM class or sa.Table
     values_list: list[dict],
     index_elements: list[str],
 ):
-    """Bulk INSERT ... ON CONFLICT (index_elements) DO NOTHING on postgresql or
-    sqlite. Caller is responsible for committing."""
+    """Bulk INSERT ... ON CONFLICT (index_elements) DO NOTHING on postgresql
+    or sqlite. Caller is responsible for committing."""
     if not values_list:
         return
     insert = _insert_factory_for_dialect(db.bind.dialect.name)

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -283,6 +283,16 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
             yield session
 
 
+def _insert_factory_for_dialect(dialect_name: str):
+    if dialect_name == 'postgresql':
+        return postgresql.insert
+    if dialect_name == 'sqlite':
+        return sqlite.insert
+    raise NotImplementedError(
+        f'insert_on_conflict_nothing: unsupported dialect {dialect_name!r}; only postgresql and sqlite are supported'
+    )
+
+
 async def insert_on_conflict_nothing(
     db: AsyncSession, target, values: dict, index_elements: list[str]
 ):
@@ -290,13 +300,21 @@ async def insert_on_conflict_nothing(
     *target* (mapped ORM class or sa.Table) on postgresql or sqlite. Caller
     is responsible for committing."""
     bind = await db.connection()
-    dialect = bind.dialect.name
-    if dialect == 'postgresql':
-        stmt = postgresql.insert(target).values(**values)
-    elif dialect == 'sqlite':
-        stmt = sqlite.insert(target).values(**values)
-    else:
-        raise NotImplementedError(
-            f'insert_on_conflict_nothing: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
-        )
-    await db.execute(stmt.on_conflict_do_nothing(index_elements=index_elements))
+    insert = _insert_factory_for_dialect(bind.dialect.name)
+    await db.execute(
+        insert(target).values(**values).on_conflict_do_nothing(index_elements=index_elements)
+    )
+
+
+async def insert_all_on_conflict_nothing(
+    db: AsyncSession, target, values_list: list[dict], index_elements: list[str]
+):
+    """Bulk INSERT ... ON CONFLICT (index_elements) DO NOTHING on postgresql or
+    sqlite. Caller is responsible for committing."""
+    if not values_list:
+        return
+    bind = await db.connection()
+    insert = _insert_factory_for_dialect(bind.dialect.name)
+    await db.execute(
+        insert(target).values(values_list).on_conflict_do_nothing(index_elements=index_elements)
+    )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -280,3 +280,24 @@ async def get_async_db_context(db: Optional[AsyncSession] = None):
     else:
         async with get_async_db() as session:
             yield session
+
+
+async def insert_ignore_conflict(
+    db: AsyncSession, model, values: dict, conflict_cols: list[str]
+):
+    """Execute INSERT ... ON CONFLICT (conflict_cols) DO NOTHING against *model*.
+
+    Dialect-specific because SQLAlchemy's core Insert doesn't expose ON CONFLICT
+    portably; we support postgresql and sqlite.
+    """
+    from sqlalchemy.dialects import postgresql, sqlite
+
+    bind = await db.connection()
+    dialect = bind.dialect.name
+    if dialect == 'postgresql':
+        stmt = postgresql.insert(model).values(**values)
+    elif dialect == 'sqlite':
+        stmt = sqlite.insert(model).values(**values)
+    else:
+        raise NotImplementedError(f'insert_ignore_conflict: unsupported dialect {dialect!r}')
+    await db.execute(stmt.on_conflict_do_nothing(index_elements=conflict_cols))

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -337,7 +337,8 @@ async def insert_all_on_conflict_nothing(
         return
     dialect_name = db.get_bind().dialect.name
     insert = _insert_for_dialect(dialect_name)
-    # Max width across all dicts, so a heterogeneous batch can't overshoot.
+    # Bind-count budget uses the widest dict. Callers must still pass rows
+    # with matching keys - SA won't infer a uniform column set otherwise.
     batch_size = sql_param_batch(dialect_name, cols_per_row=max(len(v) for v in values_list))
     for start in range(0, len(values_list), batch_size):
         batch = values_list[start:start + batch_size]

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -293,9 +293,7 @@ def _insert_for_dialect(dialect_name: str):
     )
 
 
-# Per-statement bind-parameter budget. Postgres allows 65,535; SQLite < 3.32
-# (May 2020) caps at 999. Callers pass their row width to get a safe row
-# batch size. For single-column IN predicates, pass cols_per_row=1.
+# PG caps statements at 65,535 binds; SQLite < 3.32 (May 2020) caps at 999.
 _PG_MAX_BIND_PARAMS = 65_000
 _SQLITE_MAX_BIND_PARAMS = 900
 

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -1,0 +1,192 @@
+"""Add chat_tag table
+
+Revision ID: 17a6d37e23d2
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-17 00:00:00.000000
+
+"""
+
+import json
+import logging
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+log = logging.getLogger(__name__)
+
+revision: str = '17a6d37e23d2'
+down_revision: Union[str, None] = 'e1f2a3b4c5d6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Keyset chunk size. Each chunk is fully materialized with .fetchall() before
+# the next query runs, so no server-side cursor stays open across chunks.
+# This avoids the OOM / cursor-timeout failures seen on very large Postgres
+# deployments when earlier migrations used yield_per streaming.
+CHUNK_SIZE = 1000
+LOG_EVERY = 50_000
+
+
+def _normalize_tag_id(raw: str) -> str:
+    return raw.replace(' ', '_').lower()
+
+
+def upgrade() -> None:
+    # Step 1: Create chat_tag table
+    op.create_table(
+        'chat_tag',
+        sa.Column('chat_id', sa.String(), nullable=False),
+        sa.Column('tag_id', sa.String(), nullable=False),
+        sa.Column('user_id', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('chat_id', 'tag_id', 'user_id', name='pk_chat_tag'),
+        sa.ForeignKeyConstraint(
+            ['chat_id'],
+            ['chat.id'],
+            name='fk_chat_tag_chat_id',
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['tag_id', 'user_id'],
+            ['tag.id', 'tag.user_id'],
+            name='fk_chat_tag_tag',
+            ondelete='CASCADE',
+        ),
+    )
+    op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
+    op.create_index('chat_tag_chat_idx', 'chat_tag', ['chat_id'])
+
+    # Step 2: Backfill from chat.meta['tags']
+    conn = op.get_bind()
+
+    chat = sa.table(
+        'chat',
+        sa.column('id', sa.String()),
+        sa.column('user_id', sa.String()),
+        sa.column('meta', sa.JSON()),
+    )
+    tag = sa.table(
+        'tag',
+        sa.column('id', sa.String()),
+        sa.column('name', sa.String()),
+        sa.column('user_id', sa.String()),
+        sa.column('meta', sa.JSON()),
+    )
+    chat_tag = sa.table(
+        'chat_tag',
+        sa.column('chat_id', sa.String()),
+        sa.column('tag_id', sa.String()),
+        sa.column('user_id', sa.String()),
+    )
+
+    last_id: Union[str, None] = None
+    processed = 0
+    assoc_inserted = 0
+    tags_created = 0
+
+    while True:
+        stmt = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
+        if last_id is not None:
+            stmt = stmt.where(chat.c.id > last_id)
+        stmt = stmt.limit(CHUNK_SIZE)
+
+        # .fetchall() fully materializes and releases the cursor immediately.
+        # Do NOT switch to yield_per / stream_results here - holding a single
+        # server-side cursor open across a long backfill has caused OOM /
+        # connection resets on large PostgreSQL deployments.
+        rows = conn.execute(stmt).fetchall()
+        if not rows:
+            break
+
+        known_tags_this_chunk: set = set()
+
+        for row in rows:
+            chat_id = row.id
+            user_id = row.user_id
+            meta = row.meta
+
+            if isinstance(meta, str):
+                try:
+                    meta = json.loads(meta)
+                except Exception:
+                    meta = None
+            if not isinstance(meta, dict):
+                continue
+
+            tag_names = meta.get('tags')
+            if not isinstance(tag_names, list) or not tag_names:
+                continue
+
+            seen_in_chat: set = set()
+            for raw in tag_names:
+                if not isinstance(raw, str):
+                    continue
+                tag_id = _normalize_tag_id(raw)
+                if not tag_id or tag_id in seen_in_chat:
+                    continue
+                seen_in_chat.add(tag_id)
+
+                tag_key = (tag_id, user_id)
+                if tag_key not in known_tags_this_chunk:
+                    sp = conn.begin_nested()
+                    try:
+                        exists = conn.execute(
+                            sa.select(tag.c.id).where(
+                                tag.c.id == tag_id,
+                                tag.c.user_id == user_id,
+                            )
+                        ).first()
+                        if exists is None:
+                            conn.execute(
+                                sa.insert(tag).values(
+                                    id=tag_id,
+                                    name=tag_id,
+                                    user_id=user_id,
+                                    meta=None,
+                                )
+                            )
+                            tags_created += 1
+                        sp.commit()
+                        known_tags_this_chunk.add(tag_key)
+                    except Exception as e:
+                        sp.rollback()
+                        log.warning(
+                            f'chat_tag backfill: ensure tag failed for ({tag_id}, {user_id}): {e}'
+                        )
+                        continue
+
+                sp = conn.begin_nested()
+                try:
+                    conn.execute(
+                        sa.insert(chat_tag).values(
+                            chat_id=chat_id,
+                            tag_id=tag_id,
+                            user_id=user_id,
+                        )
+                    )
+                    sp.commit()
+                    assoc_inserted += 1
+                except Exception:
+                    # Duplicate PK on re-run is expected and tolerated.
+                    sp.rollback()
+
+        last_id = rows[-1].id
+        processed += len(rows)
+
+        if processed // LOG_EVERY != (processed - len(rows)) // LOG_EVERY:
+            log.info(
+                f'chat_tag backfill progress: {processed} chats processed, '
+                f'{assoc_inserted} associations inserted, {tags_created} tags created, '
+                f'last_id={last_id}'
+            )
+
+    log.info(
+        f'chat_tag backfill complete: {processed} chats processed, '
+        f'{assoc_inserted} associations inserted, {tags_created} tags created'
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('chat_tag_chat_idx', table_name='chat_tag')
+    op.drop_index('chat_tag_user_tag_idx', table_name='chat_tag')
+    op.drop_table('chat_tag')

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -225,7 +225,6 @@ def upgrade() -> None:
         f'{meta_rows_stripped} meta rows stripped'
     )
 
-    # chat_id-only lookups are covered by the PK's leading column.
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
 
 

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,8 +26,10 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Keeps bulk INSERTs under Postgres' 65,535 bind-parameter limit even when
-# a page has many tags per chat.
+# Per-INSERT row cap. Postgres limits a statement to 65,535 bind parameters,
+# and a chat page with many tags per chat can push the flattened payload past
+# it. 5000 rows stays comfortably under the ceiling at our widest table
+# (tag has 4 cols = 20,000 binds).
 INSERT_BATCH_ROWS = 5000
 
 LOG_EVERY_CHATS = 50_000
@@ -37,8 +39,8 @@ def _normalize_tag_id(raw: str) -> str:
     return raw.replace(' ', '_').lower()
 
 
-def _chunked(seq: Sequence, size: int) -> Iterable[list]:
-    it = iter(seq)
+def _chunked(source: Iterable, size: int) -> Iterable[list]:
+    it = iter(source)
     while True:
         batch = list(islice(it, size))
         if not batch:
@@ -83,8 +85,6 @@ def upgrade() -> None:
             ondelete='CASCADE',
         ),
     )
-    # chat_id-only lookups are covered by the PK's leading column.
-    op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
 
     conn = op.get_bind()
 
@@ -199,6 +199,27 @@ def upgrade() -> None:
         f'{chat_tag_rows_inserted} associations inserted, {tag_rows_inserted} tags inserted'
     )
 
+    # chat_id-only lookups are covered by the PK's leading column.
+    op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
+
+    # Strip meta['tags'] now that chat_tag is the source of truth - otherwise
+    # ChatModel responses would leak the stale JSON tag list. Downgrade
+    # rebuilds meta['tags'] from chat_tag.
+    dialect = conn.dialect.name
+    if dialect == 'postgresql':
+        conn.execute(sa.text(
+            "UPDATE chat SET meta = meta - 'tags' WHERE meta ? 'tags'"
+        ))
+    elif dialect == 'sqlite':
+        conn.execute(sa.text(
+            "UPDATE chat SET meta = json_remove(meta, '$.tags') "
+            "WHERE json_extract(meta, '$.tags') IS NOT NULL"
+        ))
+    else:
+        raise NotImplementedError(
+            f'chat_tag migration: unsupported dialect {dialect!r}'
+        )
+
 
 def downgrade() -> None:
     # Post-upgrade the app stops writing meta['tags'], so we must reserialize
@@ -214,46 +235,43 @@ def downgrade() -> None:
         'chat_tag',
         sa.column('chat_id', sa.String()),
         sa.column('tag_id', sa.String()),
-        sa.column('user_id', sa.String()),
     )
 
     last_chat_id: Union[str, None] = None
     chats_rewritten = 0
+    bulk_update = (
+        sa.update(chat)
+        .where(chat.c.id == sa.bindparam('target_chat_id'))
+        .values(meta=sa.bindparam('new_meta'))
+    )
 
+    # Paginate by chat.id so a single heavily-tagged chat can never span
+    # page boundaries (avoids the "truncated tag list" edge case).
     while True:
-        tag_ids_by_chat_query = (
-            sa.select(chat_tag.c.chat_id, chat_tag.c.tag_id)
-            .order_by(chat_tag.c.chat_id)
-        )
+        chat_page_query = sa.select(chat.c.id, chat.c.meta).order_by(chat.c.id)
         if last_chat_id is not None:
-            tag_ids_by_chat_query = tag_ids_by_chat_query.where(chat_tag.c.chat_id > last_chat_id)
-        tag_ids_by_chat_query = tag_ids_by_chat_query.limit(CHAT_PAGE_SIZE * 50)
-        rows = conn.execute(tag_ids_by_chat_query).fetchall()
-        if not rows:
+            chat_page_query = chat_page_query.where(chat.c.id > last_chat_id)
+        chat_page_query = chat_page_query.limit(CHAT_PAGE_SIZE)
+
+        page_rows = conn.execute(chat_page_query).fetchall()
+        if not page_rows:
             break
 
-        tag_ids_by_chat_id: dict[str, list[str]] = {}
-        for row in rows:
-            tag_ids_by_chat_id.setdefault(row.chat_id, []).append(row.tag_id)
+        chat_ids_in_page = [row.id for row in page_rows]
+        existing_meta_by_chat_id = {row.id: row.meta for row in page_rows}
 
-        # The last chat_id in the batch may have been truncated mid-way
-        # through its tags, so defer it to the next iteration.
-        chat_ids_in_order = list(tag_ids_by_chat_id.keys())
-        if len(chat_ids_in_order) > 1:
-            complete_chat_ids = chat_ids_in_order[:-1]
-            next_cursor = complete_chat_ids[-1]
-        else:
-            complete_chat_ids = chat_ids_in_order
-            next_cursor = chat_ids_in_order[-1]
+        tag_rows = conn.execute(
+            sa.select(chat_tag.c.chat_id, chat_tag.c.tag_id).where(
+                chat_tag.c.chat_id.in_(chat_ids_in_page)
+            )
+        ).fetchall()
+        tag_ids_by_chat_id: dict[str, list[str]] = {cid: [] for cid in chat_ids_in_page}
+        for tag_row in tag_rows:
+            tag_ids_by_chat_id[tag_row.chat_id].append(tag_row.tag_id)
 
-        for chat_id in complete_chat_ids:
-            tag_ids = tag_ids_by_chat_id[chat_id]
-            existing_meta_row = conn.execute(
-                sa.select(chat.c.meta).where(chat.c.id == chat_id)
-            ).first()
-            if existing_meta_row is None:
-                continue
-            existing_meta = existing_meta_row.meta
+        update_params = []
+        for chat_id in chat_ids_in_page:
+            existing_meta = existing_meta_by_chat_id.get(chat_id)
             if isinstance(existing_meta, str):
                 try:
                     existing_meta = json.loads(existing_meta)
@@ -261,13 +279,14 @@ def downgrade() -> None:
                     existing_meta = {}
             if not isinstance(existing_meta, dict):
                 existing_meta = {}
-            merged_meta = {**existing_meta, 'tags': tag_ids}
-            conn.execute(
-                sa.update(chat).where(chat.c.id == chat_id).values(meta=merged_meta)
-            )
-            chats_rewritten += 1
+            merged_meta = {**existing_meta, 'tags': tag_ids_by_chat_id[chat_id]}
+            update_params.append({'target_chat_id': chat_id, 'new_meta': merged_meta})
 
-        last_chat_id = next_cursor
+        if update_params:
+            conn.execute(bulk_update, update_params)
+            chats_rewritten += len(update_params)
+
+        last_chat_id = chat_ids_in_page[-1]
 
     log.info(f'chat_tag downgrade: serialized tags back into meta for {chats_rewritten} chats')
 

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,11 +26,16 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Ceiling guard against each dialect's bind-parameter limit. PG allows
-# 65,535; SQLite < 3.32 (May 2020) caps at 999. Mirrors
-# open_webui.internal.db.sql_param_batch - keep in sync.
-SQL_PARAM_BATCH_PG = 5000
-SQL_PARAM_BATCH_SQLITE = 200
+# Per-statement bind-parameter budget per dialect. PG allows 65,535;
+# SQLite < 3.32 (May 2020) caps at 999. Mirrors
+# open_webui.internal.db._PG_MAX_BIND_PARAMS / _SQLITE_MAX_BIND_PARAMS.
+_PG_MAX_BIND_PARAMS = 65_000
+_SQLITE_MAX_BIND_PARAMS = 900
+
+
+def _row_batch_size(dialect: str, cols_per_row: int) -> int:
+    budget = _SQLITE_MAX_BIND_PARAMS if dialect == 'sqlite' else _PG_MAX_BIND_PARAMS
+    return max(1, budget // max(1, cols_per_row))
 
 LOG_EVERY_CHATS = 50_000
 
@@ -54,7 +59,7 @@ def _bulk_insert_on_conflict_nothing(conn, table, rows, index_elements):
     if not rows:
         return
     dialect = conn.dialect.name
-    batch_size = SQL_PARAM_BATCH_SQLITE if dialect == 'sqlite' else SQL_PARAM_BATCH_PG
+    batch_size = _row_batch_size(dialect, cols_per_row=len(rows[0]))
     for batch in _chunked(rows, batch_size):
         if dialect == 'postgresql':
             stmt = postgresql.insert(table).values(batch).on_conflict_do_nothing(index_elements=index_elements)
@@ -201,7 +206,8 @@ def upgrade() -> None:
             # the first-seen name.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
-            key_batch_size = SQL_PARAM_BATCH_SQLITE if dialect == 'sqlite' else SQL_PARAM_BATCH_PG
+            # tuple_(id, user_id) = 2 binds per row.
+            key_batch_size = _row_batch_size(dialect, cols_per_row=2)
             for key_batch in _chunked(tag_keys, key_batch_size):
                 existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
                     sa.tuple_(tag.c.id, tag.c.user_id).in_(key_batch)

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -23,10 +23,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 # Keyset chunk size. Each chunk is fully materialized with .fetchall() and the
 # associated INSERTs run as bulk dialect-specific upserts, so no server-side
-# cursor stays open across chunks and no per-row savepoints are created.
-# Earlier migrations that used yield_per streaming held a single cursor for
-# the full run, which caused OOM / connection resets on large PostgreSQL
-# deployments.
+# cursor stays open across chunks. Earlier migrations that used yield_per
+# streaming held a single cursor for the full run, which caused OOM /
+# connection resets on large PostgreSQL deployments.
+#
+# 1000 is a balance between round-trip overhead (too small) and per-chunk
+# memory plus Postgres' ~32k bind-parameter limit on bulk INSERT (too large);
+# at 3 columns per row that caps us well below the limit and keeps working
+# memory bounded.
+#
+# Note for very large (>10M chat rows) deployments: this migration runs
+# inside Alembic's default transaction, so the WAL write grows with row
+# count. Run during a maintenance window, or split DDL from backfill by
+# disabling transactional_ddl on this revision.
 CHUNK_SIZE = 1000
 LOG_EVERY = 50_000
 
@@ -36,11 +45,13 @@ def _normalize_tag_id(raw: str) -> str:
 
 
 def _bulk_insert_ignore(conn, table, rows, conflict_cols):
-    """Dialect-aware bulk INSERT that ignores duplicate key conflicts.
+    """Dialect-aware bulk INSERT that skips duplicate key conflicts.
 
     Postgres: INSERT ... ON CONFLICT (...) DO NOTHING.
     SQLite:   INSERT OR IGNORE.
-    Other:    fall back to a portable INSERT inside a savepoint.
+    Other dialects are not supported - open-webui officially targets PG and
+    SQLite only, and a savepoint fallback here would silently swallow real
+    data-integrity errors alongside the intended duplicate-key skip.
     """
     if not rows:
         return
@@ -52,22 +63,9 @@ def _bulk_insert_ignore(conn, table, rows, conflict_cols):
         stmt = sqlite.insert(table).values(rows).prefix_with('OR IGNORE')
         conn.execute(stmt)
     else:
-        # Portable fallback: wrap the bulk insert in a savepoint so a dup key
-        # doesn't poison the outer migration transaction.
-        sp = conn.begin_nested()
-        try:
-            conn.execute(sa.insert(table).values(rows))
-            sp.commit()
-        except Exception:
-            sp.rollback()
-            # Row-by-row fallback under savepoints.
-            for row in rows:
-                rp = conn.begin_nested()
-                try:
-                    conn.execute(sa.insert(table).values(**row))
-                    rp.commit()
-                except Exception:
-                    rp.rollback()
+        raise NotImplementedError(
+            f'chat_tag backfill: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+        )
 
 
 def upgrade() -> None:
@@ -119,8 +117,8 @@ def upgrade() -> None:
 
     last_id: Union[str, None] = None
     processed = 0
-    assoc_batched = 0
-    tags_batched = 0
+    assoc_queued = 0
+    tags_queued = 0
     next_log_at = LOG_EVERY
 
     while True:
@@ -135,10 +133,12 @@ def upgrade() -> None:
         if not rows:
             break
 
-        # Collect the first raw display name seen per (tag_id, user_id) so
-        # freshly created tag rows keep the user's capitalization/spacing
-        # instead of the normalized id.
-        tag_display: dict[tuple, str] = {}
+        # First raw display name seen per (tag_id, user_id) "wins" and becomes
+        # the name on any newly-created tag row. Chunks iterate rows in
+        # chat.id order, so the winner is deterministic but otherwise
+        # arbitrary if the same tag exists under multiple casings across
+        # different chats. Pre-existing tag rows are never overwritten.
+        tag_display: dict[tuple[str, str], str] = {}
         assoc_rows: list[dict] = []
 
         for row in rows:
@@ -156,15 +156,15 @@ def upgrade() -> None:
                 continue
 
             seen_in_chat: set = set()
-            for raw in tag_names:
-                if not isinstance(raw, str):
+            for raw_tag_name in tag_names:
+                if not isinstance(raw_tag_name, str):
                     continue
-                tag_id = _normalize_tag_id(raw)
+                tag_id = _normalize_tag_id(raw_tag_name)
                 if not tag_id or tag_id in seen_in_chat:
                     continue
                 seen_in_chat.add(tag_id)
 
-                tag_display.setdefault((tag_id, row.user_id), raw)
+                tag_display.setdefault((tag_id, row.user_id), raw_tag_name)
                 assoc_rows.append(
                     {'chat_id': row.id, 'tag_id': tag_id, 'user_id': row.user_id}
                 )
@@ -202,7 +202,7 @@ def upgrade() -> None:
             ]
             if new_tag_rows:
                 _bulk_insert_ignore(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
-                tags_batched += len(new_tag_rows)
+                tags_queued += len(new_tag_rows)
 
         # Bulk-insert chat_tag associations. Dedupe payload list first; duplicate
         # PK collisions (e.g. re-run after partial failure) are swallowed by the
@@ -214,7 +214,7 @@ def upgrade() -> None:
             _bulk_insert_ignore(
                 conn, chat_tag, unique_assocs, conflict_cols=['chat_id', 'tag_id', 'user_id']
             )
-            assoc_batched += len(unique_assocs)
+            assoc_queued += len(unique_assocs)
 
         last_id = rows[-1].id
         processed += len(rows)
@@ -222,14 +222,14 @@ def upgrade() -> None:
         if processed >= next_log_at:
             log.info(
                 f'chat_tag backfill progress: {processed} chats processed, '
-                f'{assoc_batched} associations queued, {tags_batched} tags queued, '
+                f'{assoc_queued} associations queued, {tags_queued} tags queued, '
                 f'last_id={last_id}'
             )
             next_log_at += LOG_EVERY
 
     log.info(
         f'chat_tag backfill complete: {processed} chats processed, '
-        f'{assoc_batched} associations queued, {tags_batched} tags queued'
+        f'{assoc_queued} associations queued, {tags_queued} tags queued'
     )
 
 

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,18 +26,14 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Per-INSERT row cap (ceiling guard). Postgres limits a statement to 65,535
-# bind parameters; a page with many tags per chat could in theory push past
-# that. Realistic workloads stay far below 5000 rows per page, so this is
-# defensive - chunked execution only kicks in on degenerate inputs.
+# Ceiling guard against Postgres' 65,535 bind-param statement limit.
 INSERT_BATCH_ROWS = 5000
 
 LOG_EVERY_CHATS = 50_000
 
 
 def _normalize_tag_id(raw: str) -> str:
-    # Duplicated from open_webui.models.tags.normalize_tag_id; migrations must
-    # be self-contained (models evolve independently). Keep in sync.
+    # Must stay in sync with open_webui.models.tags.normalize_tag_id.
     return raw.replace(' ', '_').lower()
 
 
@@ -206,10 +202,8 @@ def upgrade() -> None:
             chat_tag_rows_inserted += len(chat_tag_payload)
 
         if meta_strip_payload:
-            # Paginated executemany avoids a single full-table UPDATE that
-            # would hold write locks and bloat WAL on large deployments.
-            # (Also: meta is sa.JSON, so the PG json - 'tags' operator
-            # isn't available without a jsonb cast.)
+            # Paginated; a single full-table UPDATE holds write locks too long.
+            # (Also: meta is sa.JSON, so PG's json - 'tags' needs a jsonb cast.)
             conn.execute(strip_meta_update, meta_strip_payload)
             meta_rows_stripped += len(meta_strip_payload)
 
@@ -236,12 +230,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Post-upgrade the app stops writing meta['tags'], so we must reserialize
-    # chat_tag back into meta before the drop or lose every post-upgrade tag.
-    # Lossy for display casing: the reserialized tag list uses the normalized
-    # tag_id, not the original tag.name. Round-tripping upgrade -> downgrade
-    # on already-normalized data is a no-op; original user casings only
-    # survive re-running upgrade (which reads from tag.name).
+    # Reserialize chat_tag into meta['tags'] before the drop (post-upgrade
+    # writes only hit chat_tag). Lossy: rebuilt from tag_id, not tag.name.
     conn = op.get_bind()
 
     chat = sa.table(

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -36,6 +36,8 @@ LOG_EVERY_CHATS = 50_000
 
 
 def _normalize_tag_id(raw: str) -> str:
+    # Duplicated from open_webui.models.tags.normalize_tag_id; migrations must
+    # be self-contained (models evolve independently). Keep in sync.
     return raw.replace(' ', '_').lower()
 
 
@@ -48,19 +50,19 @@ def _chunked(source: Iterable, size: int) -> Iterable[list]:
         yield batch
 
 
-def _bulk_insert_skip_conflicts(conn, table, rows, conflict_cols):
-    """Bulk INSERT that skips duplicate-key conflicts. PG and SQLite only."""
+def _bulk_insert_on_conflict_nothing(conn, table, rows, index_elements):
+    """Bulk INSERT ... ON CONFLICT DO NOTHING. PG and SQLite only."""
     if not rows:
         return
     dialect = conn.dialect.name
     for batch in _chunked(rows, INSERT_BATCH_ROWS):
         if dialect == 'postgresql':
-            stmt = postgresql.insert(table).values(batch).on_conflict_do_nothing(index_elements=conflict_cols)
+            stmt = postgresql.insert(table).values(batch).on_conflict_do_nothing(index_elements=index_elements)
         elif dialect == 'sqlite':
-            stmt = sqlite.insert(table).values(batch).on_conflict_do_nothing(index_elements=conflict_cols)
+            stmt = sqlite.insert(table).values(batch).on_conflict_do_nothing(index_elements=index_elements)
         else:
             raise NotImplementedError(
-                f'_bulk_insert_skip_conflicts: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+                f'_bulk_insert_on_conflict_nothing: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
             )
         conn.execute(stmt)
 
@@ -188,18 +190,18 @@ def upgrade() -> None:
                 existing_tag_keys.add((existing_row.id, existing_row.user_id))
 
             new_tag_rows = [
-                {'id': tid, 'name': raw_name, 'user_id': uid, 'meta': None}
+                {'id': tid, 'name': raw_name, 'user_id': uid}
                 for (tid, uid), raw_name in display_name_by_tag_key.items()
                 if (tid, uid) not in existing_tag_keys
             ]
             if new_tag_rows:
-                _bulk_insert_skip_conflicts(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
+                _bulk_insert_on_conflict_nothing(conn, tag, new_tag_rows, index_elements=['id', 'user_id'])
                 tag_rows_inserted += len(new_tag_rows)
 
         if chat_tag_payload:
-            _bulk_insert_skip_conflicts(
+            _bulk_insert_on_conflict_nothing(
                 conn, chat_tag, chat_tag_payload,
-                conflict_cols=['chat_id', 'tag_id', 'user_id'],
+                index_elements=['chat_id', 'tag_id', 'user_id'],
             )
             chat_tag_rows_inserted += len(chat_tag_payload)
 
@@ -236,6 +238,10 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Post-upgrade the app stops writing meta['tags'], so we must reserialize
     # chat_tag back into meta before the drop or lose every post-upgrade tag.
+    # Lossy for display casing: the reserialized tag list uses the normalized
+    # tag_id, not the original tag.name. Round-tripping upgrade -> downgrade
+    # on already-normalized data is a no-op; original user casings only
+    # survive re-running upgrade (which reads from tag.name).
     conn = op.get_bind()
 
     chat = sa.table(

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,10 +26,10 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Per-INSERT row cap. Postgres limits a statement to 65,535 bind parameters,
-# and a chat page with many tags per chat can push the flattened payload past
-# it. 5000 rows stays comfortably under the ceiling at our widest table
-# (tag has 4 cols = 20,000 binds).
+# Per-INSERT row cap (ceiling guard). Postgres limits a statement to 65,535
+# bind parameters; a page with many tags per chat could in theory push past
+# that. Realistic workloads stay far below 5000 rows per page, so this is
+# defensive - chunked execution only kicks in on degenerate inputs.
 INSERT_BATCH_ROWS = 5000
 
 LOG_EVERY_CHATS = 50_000
@@ -60,7 +60,7 @@ def _bulk_insert_skip_conflicts(conn, table, rows, conflict_cols):
             stmt = sqlite.insert(table).values(batch).on_conflict_do_nothing(index_elements=conflict_cols)
         else:
             raise NotImplementedError(
-                f'chat_tag backfill: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+                f'_bulk_insert_skip_conflicts: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
             )
         conn.execute(stmt)
 
@@ -112,7 +112,14 @@ def upgrade() -> None:
     chats_processed = 0
     chat_tag_rows_inserted = 0
     tag_rows_inserted = 0
-    next_log_threshold = LOG_EVERY_CHATS
+    meta_rows_stripped = 0
+    next_log_threshold = 0  # log the first page unconditionally
+
+    strip_meta_update = (
+        sa.update(chat)
+        .where(chat.c.id == sa.bindparam('target_chat_id'))
+        .values(meta=sa.bindparam('new_meta'))
+    )
 
     while True:
         chat_page_query = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
@@ -128,6 +135,7 @@ def upgrade() -> None:
         # pre-existing tag rows are never overwritten.
         display_name_by_tag_key: dict[tuple[str, str], str] = {}
         chat_tag_payload: list[dict] = []
+        meta_strip_payload: list[dict] = []
 
         for chat_row in chat_rows:
             meta = chat_row.meta
@@ -141,6 +149,13 @@ def upgrade() -> None:
 
             raw_tag_names = meta.get('tags')
             if not isinstance(raw_tag_names, list) or not raw_tag_names:
+                # Still strip the 'tags' key if present but empty/malformed,
+                # so meta is consistently tag-free post-upgrade.
+                if 'tags' in meta:
+                    stripped_meta = {k: v for k, v in meta.items() if k != 'tags'}
+                    meta_strip_payload.append(
+                        {'target_chat_id': chat_row.id, 'new_meta': stripped_meta}
+                    )
                 continue
 
             seen_tag_ids_in_chat: set[str] = set()
@@ -156,6 +171,11 @@ def upgrade() -> None:
                 chat_tag_payload.append(
                     {'chat_id': chat_row.id, 'tag_id': tag_id, 'user_id': chat_row.user_id}
                 )
+
+            stripped_meta = {k: v for k, v in meta.items() if k != 'tags'}
+            meta_strip_payload.append(
+                {'target_chat_id': chat_row.id, 'new_meta': stripped_meta}
+            )
 
         if display_name_by_tag_key:
             # Row-value IN works on PG and SQLite >= 3.15.
@@ -183,6 +203,14 @@ def upgrade() -> None:
             )
             chat_tag_rows_inserted += len(chat_tag_payload)
 
+        if meta_strip_payload:
+            # Paginated executemany avoids a single full-table UPDATE that
+            # would hold write locks and bloat WAL on large deployments.
+            # (Also: meta is sa.JSON, so the PG json - 'tags' operator
+            # isn't available without a jsonb cast.)
+            conn.execute(strip_meta_update, meta_strip_payload)
+            meta_rows_stripped += len(meta_strip_payload)
+
         last_chat_id = chat_rows[-1].id
         chats_processed += len(chat_rows)
 
@@ -190,35 +218,19 @@ def upgrade() -> None:
             log.info(
                 f'chat_tag backfill progress: {chats_processed} chats processed, '
                 f'{chat_tag_rows_inserted} associations inserted, '
-                f'{tag_rows_inserted} tags inserted, last_chat_id={last_chat_id}'
+                f'{tag_rows_inserted} tags inserted, '
+                f'{meta_rows_stripped} meta rows stripped, last_chat_id={last_chat_id}'
             )
-            next_log_threshold += LOG_EVERY_CHATS
+            next_log_threshold = chats_processed + LOG_EVERY_CHATS
 
     log.info(
         f'chat_tag backfill complete: {chats_processed} chats processed, '
-        f'{chat_tag_rows_inserted} associations inserted, {tag_rows_inserted} tags inserted'
+        f'{chat_tag_rows_inserted} associations inserted, {tag_rows_inserted} tags inserted, '
+        f'{meta_rows_stripped} meta rows stripped'
     )
 
     # chat_id-only lookups are covered by the PK's leading column.
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
-
-    # Strip meta['tags'] now that chat_tag is the source of truth - otherwise
-    # ChatModel responses would leak the stale JSON tag list. Downgrade
-    # rebuilds meta['tags'] from chat_tag.
-    dialect = conn.dialect.name
-    if dialect == 'postgresql':
-        conn.execute(sa.text(
-            "UPDATE chat SET meta = meta - 'tags' WHERE meta ? 'tags'"
-        ))
-    elif dialect == 'sqlite':
-        conn.execute(sa.text(
-            "UPDATE chat SET meta = json_remove(meta, '$.tags') "
-            "WHERE json_extract(meta, '$.tags') IS NOT NULL"
-        ))
-    else:
-        raise NotImplementedError(
-            f'chat_tag migration: unsupported dialect {dialect!r}'
-        )
 
 
 def downgrade() -> None:
@@ -271,6 +283,7 @@ def downgrade() -> None:
 
         update_params = []
         for chat_id in chat_ids_in_page:
+            tag_ids = tag_ids_by_chat_id[chat_id]
             existing_meta = existing_meta_by_chat_id.get(chat_id)
             if isinstance(existing_meta, str):
                 try:
@@ -279,7 +292,11 @@ def downgrade() -> None:
                     existing_meta = {}
             if not isinstance(existing_meta, dict):
                 existing_meta = {}
-            merged_meta = {**existing_meta, 'tags': tag_ids_by_chat_id[chat_id]}
+            # Skip chats that had no tags pre-upgrade and still have none:
+            # don't grow their meta with an empty 'tags' key.
+            if not tag_ids and 'tags' not in existing_meta:
+                continue
+            merged_meta = {**existing_meta, 'tags': tag_ids}
             update_params.append({'target_chat_id': chat_id, 'new_meta': merged_meta})
 
         if update_params:

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -183,14 +183,17 @@ def upgrade() -> None:
             )
 
         if display_name_by_tag_key:
-            # Row-value IN works on PG and SQLite >= 3.15.
+            # Row-value IN works on PG and SQLite >= 3.15. Chunked so a
+            # tenant-heavy page can't push this predicate past the PG bind
+            # param ceiling.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
-            existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
-                sa.tuple_(tag.c.id, tag.c.user_id).in_(tag_keys)
-            )
-            for existing_row in conn.execute(existing_tag_query).fetchall():
-                existing_tag_keys.add((existing_row.id, existing_row.user_id))
+            for key_batch in _chunked(tag_keys, INSERT_BATCH_ROWS):
+                existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
+                    sa.tuple_(tag.c.id, tag.c.user_id).in_(key_batch)
+                )
+                for existing_row in conn.execute(existing_tag_query).fetchall():
+                    existing_tag_keys.add((existing_row.id, existing_row.user_id))
 
             new_tag_rows = [
                 {'id': tid, 'name': raw_name, 'user_id': uid}

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -116,7 +116,7 @@ def upgrade() -> None:
     strip_meta_update = (
         sa.update(chat)
         .where(chat.c.id == sa.bindparam('target_chat_id'))
-        .values(meta=sa.bindparam('new_meta'))
+        .values(meta=sa.bindparam('new_meta', type_=sa.JSON()))
     )
 
     while True:
@@ -230,7 +230,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Reserialize chat_tag into meta['tags'] before the drop (post-upgrade
-    # writes only hit chat_tag). Lossy: rebuilt from tag_id, not tag.name.
+    # writes only hit chat_tag). Lossy: rebuilt from tag_id (not tag.name)
+    # and in DB row order, not the original user-meaningful order.
     conn = op.get_bind()
 
     chat = sa.table(
@@ -249,7 +250,7 @@ def downgrade() -> None:
     bulk_update = (
         sa.update(chat)
         .where(chat.c.id == sa.bindparam('target_chat_id'))
-        .values(meta=sa.bindparam('new_meta'))
+        .values(meta=sa.bindparam('new_meta', type_=sa.JSON()))
     )
 
     # Paginate by chat.id so a single heavily-tagged chat can never span

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -308,20 +308,26 @@ def downgrade() -> None:
 
         # ORDER BY tag.name gives deterministic meta['tags'] ordering across
         # downgrade runs (row order from chat_tag is otherwise undefined).
-        tag_rows = conn.execute(
-            sa.select(chat_tag.c.chat_id, tag.c.name)
-            .select_from(
-                chat_tag.join(
-                    tag,
-                    sa.and_(
-                        chat_tag.c.tag_id == tag.c.id,
-                        chat_tag.c.user_id == tag.c.user_id,
-                    ),
-                )
+        # IN chunked so CHAT_PAGE_SIZE > SQLite's 900-bind cap can't blow up.
+        tag_rows: list = []
+        chat_id_batch_size = _row_batch_size(dialect, cols_per_row=1)
+        for id_batch in _chunked(chat_ids_in_page, chat_id_batch_size):
+            tag_rows.extend(
+                conn.execute(
+                    sa.select(chat_tag.c.chat_id, tag.c.name)
+                    .select_from(
+                        chat_tag.join(
+                            tag,
+                            sa.and_(
+                                chat_tag.c.tag_id == tag.c.id,
+                                chat_tag.c.user_id == tag.c.user_id,
+                            ),
+                        )
+                    )
+                    .where(chat_tag.c.chat_id.in_(id_batch))
+                    .order_by(chat_tag.c.chat_id, tag.c.name)
+                ).fetchall()
             )
-            .where(chat_tag.c.chat_id.in_(chat_ids_in_page))
-            .order_by(chat_tag.c.chat_id, tag.c.name)
-        ).fetchall()
         tag_names_by_chat_id: dict[str, list[str]] = {cid: [] for cid in chat_ids_in_page}
         for tag_row in tag_rows:
             tag_names_by_chat_id[tag_row.chat_id].append(tag_row.name)

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -22,15 +22,13 @@ down_revision: Union[str, None] = 'e1f2a3b4c5d6'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# Keyset page size for the chat scan. Each page is fully drained with
-# .fetchall() so no server-side cursor stays open across pages; earlier
-# migrations that used yield_per held one cursor for the full run and
-# OOM'd large PG deployments.
+# Keyset page size for the chat scan. Each page is drained with .fetchall()
+# so no server-side cursor stays open across pages.
 CHAT_PAGE_SIZE = 1000
 
-# Hard cap on rows per bulk INSERT, so a page with many tags per chat can't
-# push past Postgres' 65,535 bind-parameter ceiling. chat_tag has 3 cols, tag
-# has 4; 5000 rows = 20,000 binds, well under the ceiling.
+# Cap rows per bulk INSERT so a page with many tags per chat can't push past
+# Postgres' 65,535 bind-parameter limit. chat_tag has 3 cols, tag has 4;
+# 5000 rows = 20,000 binds, well under the ceiling.
 INSERT_BATCH_ROWS = 5000
 
 LOG_EVERY_CHATS = 50_000
@@ -50,11 +48,7 @@ def _chunked(seq: Sequence, size: int) -> Iterable[list]:
 
 
 def _bulk_insert_skip_conflicts(conn, table, rows, conflict_cols):
-    """Bulk INSERT that skips duplicate-key conflicts. PG and SQLite only.
-
-    Both dialects scope the skip to the given conflict columns, so a real
-    integrity error on an unrelated constraint still surfaces.
-    """
+    """Bulk INSERT that skips duplicate-key conflicts. PG and SQLite only."""
     if not rows:
         return
     dialect = conn.dialect.name
@@ -90,8 +84,9 @@ def upgrade() -> None:
             ondelete='CASCADE',
         ),
     )
+    # Single secondary index covers the "list chats for this tag" path.
+    # A chat_id-only index would be redundant with the PK's leading column.
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
-    op.create_index('chat_tag_chat_idx', 'chat_tag', ['chat_id'])
 
     conn = op.get_bind()
 
@@ -117,24 +112,22 @@ def upgrade() -> None:
 
     last_chat_id: Union[str, None] = None
     chats_processed = 0
-    chat_tag_rows_queued = 0
-    tag_rows_queued = 0
+    chat_tag_rows_inserted = 0
+    tag_rows_inserted = 0
     next_log_threshold = LOG_EVERY_CHATS
 
     while True:
-        page_stmt = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
+        chat_page_query = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
         if last_chat_id is not None:
-            page_stmt = page_stmt.where(chat.c.id > last_chat_id)
-        page_stmt = page_stmt.limit(CHAT_PAGE_SIZE)
+            chat_page_query = chat_page_query.where(chat.c.id > last_chat_id)
+        chat_page_query = chat_page_query.limit(CHAT_PAGE_SIZE)
 
-        chat_rows = conn.execute(page_stmt).fetchall()
+        chat_rows = conn.execute(chat_page_query).fetchall()
         if not chat_rows:
             break
 
         # First raw display name seen per (tag_id, user_id) wins the name on
-        # any newly-created tag row. Deterministic per run (iteration is in
-        # chat.id order) but arbitrary across runs if the same tag appears
-        # under multiple casings. Pre-existing tag rows are never overwritten.
+        # any newly-created tag row. Pre-existing tag rows are never overwritten.
         display_name_by_tag_key: dict[tuple[str, str], str] = {}
         chat_tag_payload: list[dict] = []
 
@@ -143,7 +136,7 @@ def upgrade() -> None:
             if isinstance(meta, str):
                 try:
                     meta = json.loads(meta)
-                except Exception:
+                except (TypeError, ValueError):
                     meta = None
             if not isinstance(meta, dict):
                 continue
@@ -168,14 +161,14 @@ def upgrade() -> None:
 
         if display_name_by_tag_key:
             # One tuple-IN query covers every (tag_id, user_id) in the page,
-            # regardless of how many distinct users it spans. Both PG and
-            # SQLite >= 3.15 support row-value IN.
+            # regardless of how many distinct users it spans. PG and SQLite
+            # 3.15+ both support row-value IN.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
-            existing_stmt = sa.select(tag.c.id, tag.c.user_id).where(
+            existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
                 sa.tuple_(tag.c.id, tag.c.user_id).in_(tag_keys)
             )
-            for existing_row in conn.execute(existing_stmt).fetchall():
+            for existing_row in conn.execute(existing_tag_query).fetchall():
                 existing_tag_keys.add((existing_row.id, existing_row.user_id))
 
             new_tag_rows = [
@@ -185,20 +178,14 @@ def upgrade() -> None:
             ]
             if new_tag_rows:
                 _bulk_insert_skip_conflicts(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
-                tag_rows_queued += len(new_tag_rows)
+                tag_rows_inserted += len(new_tag_rows)
 
         if chat_tag_payload:
-            deduped_chat_tag_rows = list(
-                {
-                    (r['chat_id'], r['tag_id'], r['user_id']): r
-                    for r in chat_tag_payload
-                }.values()
-            )
             _bulk_insert_skip_conflicts(
-                conn, chat_tag, deduped_chat_tag_rows,
+                conn, chat_tag, chat_tag_payload,
                 conflict_cols=['chat_id', 'tag_id', 'user_id'],
             )
-            chat_tag_rows_queued += len(deduped_chat_tag_rows)
+            chat_tag_rows_inserted += len(chat_tag_payload)
 
         last_chat_id = chat_rows[-1].id
         chats_processed += len(chat_rows)
@@ -206,22 +193,93 @@ def upgrade() -> None:
         if chats_processed >= next_log_threshold:
             log.info(
                 f'chat_tag backfill progress: {chats_processed} chats processed, '
-                f'{chat_tag_rows_queued} associations queued, '
-                f'{tag_rows_queued} tags queued, last_chat_id={last_chat_id}'
+                f'{chat_tag_rows_inserted} associations inserted, '
+                f'{tag_rows_inserted} tags inserted, last_chat_id={last_chat_id}'
             )
             next_log_threshold += LOG_EVERY_CHATS
 
     log.info(
         f'chat_tag backfill complete: {chats_processed} chats processed, '
-        f'{chat_tag_rows_queued} associations queued, {tag_rows_queued} tags queued'
+        f'{chat_tag_rows_inserted} associations inserted, {tag_rows_inserted} tags inserted'
     )
 
 
 def downgrade() -> None:
-    # TODO(chat-tag-meta-dropped): this downgrade relies on chat.meta['tags']
-    # still being dual-written. When a future migration drops those writes,
-    # this function must serialize chat_tag rows back into meta before the
-    # drop - or refuse to run.
-    op.drop_index('chat_tag_chat_idx', table_name='chat_tag')
+    # Serialize chat_tag rows back into chat.meta['tags'] before dropping the
+    # table. Post-upgrade the app stops writing meta['tags'], so skipping this
+    # step would silently discard every tag associated after the upgrade ran.
+    conn = op.get_bind()
+
+    chat = sa.table(
+        'chat',
+        sa.column('id', sa.String()),
+        sa.column('meta', sa.JSON()),
+    )
+    chat_tag = sa.table(
+        'chat_tag',
+        sa.column('chat_id', sa.String()),
+        sa.column('tag_id', sa.String()),
+        sa.column('user_id', sa.String()),
+    )
+
+    last_chat_id: Union[str, None] = None
+    chats_rewritten = 0
+
+    while True:
+        tag_ids_by_chat_query = (
+            sa.select(chat_tag.c.chat_id, chat_tag.c.tag_id)
+            .order_by(chat_tag.c.chat_id)
+        )
+        if last_chat_id is not None:
+            tag_ids_by_chat_query = tag_ids_by_chat_query.where(chat_tag.c.chat_id > last_chat_id)
+        # Pull tags for up to CHAT_PAGE_SIZE chats per iteration. Rows come
+        # grouped by chat_id because of the ORDER BY.
+        tag_ids_by_chat_query = tag_ids_by_chat_query.limit(CHAT_PAGE_SIZE * 50)
+        rows = conn.execute(tag_ids_by_chat_query).fetchall()
+        if not rows:
+            break
+
+        tag_ids_by_chat_id: dict[str, list[str]] = {}
+        for row in rows:
+            tag_ids_by_chat_id.setdefault(row.chat_id, []).append(row.tag_id)
+
+        # Only the first CHAT_PAGE_SIZE chat_ids in the batch are guaranteed
+        # to have their complete tag list - the last chat_id in `rows` may
+        # have been truncated mid-way. Write the completed ones, keep the
+        # last chat_id's tags for the next iteration by excluding it here
+        # and using `> chat_id` as the next cursor.
+        chat_ids_in_order = list(tag_ids_by_chat_id.keys())
+        if len(chat_ids_in_order) > 1:
+            complete_chat_ids = chat_ids_in_order[:-1]
+            next_cursor = complete_chat_ids[-1]
+        else:
+            complete_chat_ids = chat_ids_in_order
+            next_cursor = chat_ids_in_order[-1]
+
+        for chat_id in complete_chat_ids:
+            tag_ids = tag_ids_by_chat_id[chat_id]
+            existing_meta_row = conn.execute(
+                sa.select(chat.c.meta).where(chat.c.id == chat_id)
+            ).first()
+            if existing_meta_row is None:
+                continue
+            existing_meta = existing_meta_row.meta
+            if isinstance(existing_meta, str):
+                try:
+                    existing_meta = json.loads(existing_meta)
+                except (TypeError, ValueError):
+                    existing_meta = {}
+            if not isinstance(existing_meta, dict):
+                existing_meta = {}
+            merged_meta = {**existing_meta, 'tags': tag_ids}
+            conn.execute(
+                sa.update(chat).where(chat.c.id == chat_id).values(meta=merged_meta)
+            )
+            chats_rewritten += 1
+
+        last_chat_id = next_cursor
+
+    log.info(f'chat_tag downgrade: serialized tags back into meta for {chats_rewritten} chats')
+
     op.drop_index('chat_tag_user_tag_idx', table_name='chat_tag')
     op.drop_table('chat_tag')

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -114,8 +114,8 @@ def upgrade() -> None:
 
     last_chat_id: Union[str, None] = None
     chats_processed = 0
-    chat_tag_rows_inserted = 0
-    tag_rows_inserted = 0
+    chat_tag_rows_submitted = 0
+    tag_rows_submitted = 0
     meta_rows_stripped = 0
     next_log_threshold = 0  # log the first page unconditionally
 
@@ -202,14 +202,14 @@ def upgrade() -> None:
             ]
             if new_tag_rows:
                 _bulk_insert_on_conflict_nothing(conn, tag, new_tag_rows, index_elements=['id', 'user_id'])
-                tag_rows_inserted += len(new_tag_rows)
+                tag_rows_submitted += len(new_tag_rows)
 
         if chat_tag_payload:
             _bulk_insert_on_conflict_nothing(
                 conn, chat_tag, chat_tag_payload,
                 index_elements=['chat_id', 'tag_id', 'user_id'],
             )
-            chat_tag_rows_inserted += len(chat_tag_payload)
+            chat_tag_rows_submitted += len(chat_tag_payload)
 
         if meta_strip_payload:
             # Paginated; a single full-table UPDATE holds write locks too long.
@@ -223,15 +223,15 @@ def upgrade() -> None:
         if chats_processed >= next_log_threshold:
             log.info(
                 f'chat_tag backfill progress: {chats_processed} chats processed, '
-                f'{chat_tag_rows_inserted} associations inserted, '
-                f'{tag_rows_inserted} tags inserted, '
+                f'{chat_tag_rows_submitted} associations submitted, '
+                f'{tag_rows_submitted} tags submitted, '
                 f'{meta_rows_stripped} meta rows stripped, last_chat_id={last_chat_id}'
             )
             next_log_threshold = chats_processed + LOG_EVERY_CHATS
 
     log.info(
         f'chat_tag backfill complete: {chats_processed} chats processed, '
-        f'{chat_tag_rows_inserted} associations inserted, {tag_rows_inserted} tags inserted, '
+        f'{chat_tag_rows_submitted} associations submitted, {tag_rows_submitted} tags submitted, '
         f'{meta_rows_stripped} meta rows stripped'
     )
 
@@ -292,6 +292,8 @@ def downgrade() -> None:
         chat_ids_in_page = [row.id for row in page_rows]
         existing_meta_by_chat_id = {row.id: row.meta for row in page_rows}
 
+        # ORDER BY tag.name gives deterministic meta['tags'] ordering across
+        # downgrade runs (row order from chat_tag is otherwise undefined).
         tag_rows = conn.execute(
             sa.select(chat_tag.c.chat_id, tag.c.name)
             .select_from(
@@ -304,6 +306,7 @@ def downgrade() -> None:
                 )
             )
             .where(chat_tag.c.chat_id.in_(chat_ids_in_page))
+            .order_by(chat_tag.c.chat_id, tag.c.name)
         ).fetchall()
         tag_names_by_chat_id: dict[str, list[str]] = {cid: [] for cid in chat_ids_in_page}
         for tag_row in tag_rows:

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -64,6 +64,12 @@ def _bulk_insert_on_conflict_nothing(conn, table, rows, index_elements):
 
 
 def upgrade() -> None:
+    dialect = op.get_bind().dialect.name
+    if dialect not in ('postgresql', 'sqlite'):
+        raise NotImplementedError(
+            f'chat_tag migration: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+        )
+
     op.create_table(
         'chat_tag',
         sa.Column('chat_id', sa.String(), nullable=False),
@@ -161,7 +167,8 @@ def upgrade() -> None:
                 if not isinstance(raw_tag_name, str):
                     continue
                 tag_id = _normalize_tag_id(raw_tag_name)
-                if not tag_id or tag_id in seen_tag_ids_in_chat:
+                # 'none' is the search sentinel; don't promote it to a real association.
+                if not tag_id or tag_id == 'none' or tag_id in seen_tag_ids_in_chat:
                     continue
                 seen_tag_ids_in_chat.add(tag_id)
 
@@ -233,6 +240,11 @@ def downgrade() -> None:
     # writes only hit chat_tag). Lossy: rebuilt from tag_id (not tag.name)
     # and in DB row order, not the original user-meaningful order.
     conn = op.get_bind()
+    dialect = conn.dialect.name
+    if dialect not in ('postgresql', 'sqlite'):
+        raise NotImplementedError(
+            f'chat_tag migration: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+        )
 
     chat = sa.table(
         'chat',

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -8,7 +8,8 @@ Create Date: 2026-04-17 00:00:00.000000
 
 import json
 import logging
-from typing import Sequence, Union
+from itertools import islice
+from typing import Iterable, Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
@@ -21,55 +22,55 @@ down_revision: Union[str, None] = 'e1f2a3b4c5d6'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# Keyset chunk size. Each chunk is fully materialized with .fetchall() and the
-# associated INSERTs run as bulk dialect-specific upserts, so no server-side
-# cursor stays open across chunks. Earlier migrations that used yield_per
-# streaming held a single cursor for the full run, which caused OOM /
-# connection resets on large PostgreSQL deployments.
-#
-# 1000 is a balance between round-trip overhead (too small) and per-chunk
-# memory plus Postgres' ~32k bind-parameter limit on bulk INSERT (too large);
-# at 3 columns per row that caps us well below the limit and keeps working
-# memory bounded.
-#
-# Note for very large (>10M chat rows) deployments: this migration runs
-# inside Alembic's default transaction, so the WAL write grows with row
-# count. Run during a maintenance window, or split DDL from backfill by
-# disabling transactional_ddl on this revision.
-CHUNK_SIZE = 1000
-LOG_EVERY = 50_000
+# Keyset page size for the chat scan. Each page is fully drained with
+# .fetchall() so no server-side cursor stays open across pages; earlier
+# migrations that used yield_per held one cursor for the full run and
+# OOM'd large PG deployments.
+CHAT_PAGE_SIZE = 1000
+
+# Hard cap on rows per bulk INSERT, so a page with many tags per chat can't
+# push past Postgres' 65,535 bind-parameter ceiling. chat_tag has 3 cols, tag
+# has 4; 5000 rows = 20,000 binds, well under the ceiling.
+INSERT_BATCH_ROWS = 5000
+
+LOG_EVERY_CHATS = 50_000
 
 
 def _normalize_tag_id(raw: str) -> str:
     return raw.replace(' ', '_').lower()
 
 
-def _bulk_insert_ignore(conn, table, rows, conflict_cols):
-    """Dialect-aware bulk INSERT that skips duplicate key conflicts.
+def _chunked(seq: Sequence, size: int) -> Iterable[list]:
+    it = iter(seq)
+    while True:
+        batch = list(islice(it, size))
+        if not batch:
+            return
+        yield batch
 
-    Postgres: INSERT ... ON CONFLICT (...) DO NOTHING.
-    SQLite:   INSERT OR IGNORE.
-    Other dialects are not supported - open-webui officially targets PG and
-    SQLite only, and a savepoint fallback here would silently swallow real
-    data-integrity errors alongside the intended duplicate-key skip.
+
+def _bulk_insert_skip_conflicts(conn, table, rows, conflict_cols):
+    """Bulk INSERT that skips duplicate-key conflicts. PG and SQLite only.
+
+    Both dialects scope the skip to the given conflict columns, so a real
+    integrity error on an unrelated constraint still surfaces.
     """
     if not rows:
         return
     dialect = conn.dialect.name
-    if dialect == 'postgresql':
-        stmt = postgresql.insert(table).values(rows).on_conflict_do_nothing(index_elements=conflict_cols)
+    for batch in _chunked(rows, INSERT_BATCH_ROWS):
+        if dialect == 'postgresql':
+            stmt = postgresql.insert(table).values(batch).on_conflict_do_nothing(index_elements=conflict_cols)
+        elif dialect == 'sqlite':
+            stmt = sqlite.insert(table).values(batch).on_conflict_do_nothing(index_elements=conflict_cols)
+        else:
+            raise NotImplementedError(
+                f'chat_tag backfill: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
+            )
         conn.execute(stmt)
-    elif dialect == 'sqlite':
-        stmt = sqlite.insert(table).values(rows).prefix_with('OR IGNORE')
-        conn.execute(stmt)
-    else:
-        raise NotImplementedError(
-            f'chat_tag backfill: unsupported dialect {dialect!r}; only postgresql and sqlite are supported'
-        )
 
 
 def upgrade() -> None:
-    # Step 1: Create chat_tag table
     op.create_table(
         'chat_tag',
         sa.Column('chat_id', sa.String(), nullable=False),
@@ -92,7 +93,6 @@ def upgrade() -> None:
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
     op.create_index('chat_tag_chat_idx', 'chat_tag', ['chat_id'])
 
-    # Step 2: Backfill from chat.meta['tags']
     conn = op.get_bind()
 
     chat = sa.table(
@@ -115,34 +115,31 @@ def upgrade() -> None:
         sa.column('user_id', sa.String()),
     )
 
-    last_id: Union[str, None] = None
-    processed = 0
-    assoc_queued = 0
-    tags_queued = 0
-    next_log_at = LOG_EVERY
+    last_chat_id: Union[str, None] = None
+    chats_processed = 0
+    chat_tag_rows_queued = 0
+    tag_rows_queued = 0
+    next_log_threshold = LOG_EVERY_CHATS
 
     while True:
-        stmt = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
-        if last_id is not None:
-            stmt = stmt.where(chat.c.id > last_id)
-        stmt = stmt.limit(CHUNK_SIZE)
+        page_stmt = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
+        if last_chat_id is not None:
+            page_stmt = page_stmt.where(chat.c.id > last_chat_id)
+        page_stmt = page_stmt.limit(CHAT_PAGE_SIZE)
 
-        # fetchall() fully materializes and releases the cursor immediately -
-        # see note at top of file on why this matters for large PG deployments.
-        rows = conn.execute(stmt).fetchall()
-        if not rows:
+        chat_rows = conn.execute(page_stmt).fetchall()
+        if not chat_rows:
             break
 
-        # First raw display name seen per (tag_id, user_id) "wins" and becomes
-        # the name on any newly-created tag row. Chunks iterate rows in
-        # chat.id order, so the winner is deterministic but otherwise
-        # arbitrary if the same tag exists under multiple casings across
-        # different chats. Pre-existing tag rows are never overwritten.
-        tag_display: dict[tuple[str, str], str] = {}
-        assoc_rows: list[dict] = []
+        # First raw display name seen per (tag_id, user_id) wins the name on
+        # any newly-created tag row. Deterministic per run (iteration is in
+        # chat.id order) but arbitrary across runs if the same tag appears
+        # under multiple casings. Pre-existing tag rows are never overwritten.
+        display_name_by_tag_key: dict[tuple[str, str], str] = {}
+        chat_tag_payload: list[dict] = []
 
-        for row in rows:
-            meta = row.meta
+        for chat_row in chat_rows:
+            meta = chat_row.meta
             if isinstance(meta, str):
                 try:
                     meta = json.loads(meta)
@@ -151,93 +148,80 @@ def upgrade() -> None:
             if not isinstance(meta, dict):
                 continue
 
-            tag_names = meta.get('tags')
-            if not isinstance(tag_names, list) or not tag_names:
+            raw_tag_names = meta.get('tags')
+            if not isinstance(raw_tag_names, list) or not raw_tag_names:
                 continue
 
-            seen_in_chat: set = set()
-            for raw_tag_name in tag_names:
+            seen_tag_ids_in_chat: set[str] = set()
+            for raw_tag_name in raw_tag_names:
                 if not isinstance(raw_tag_name, str):
                     continue
                 tag_id = _normalize_tag_id(raw_tag_name)
-                if not tag_id or tag_id in seen_in_chat:
+                if not tag_id or tag_id in seen_tag_ids_in_chat:
                     continue
-                seen_in_chat.add(tag_id)
+                seen_tag_ids_in_chat.add(tag_id)
 
-                tag_display.setdefault((tag_id, row.user_id), raw_tag_name)
-                assoc_rows.append(
-                    {'chat_id': row.id, 'tag_id': tag_id, 'user_id': row.user_id}
+                display_name_by_tag_key.setdefault((tag_id, chat_row.user_id), raw_tag_name)
+                chat_tag_payload.append(
+                    {'chat_id': chat_row.id, 'tag_id': tag_id, 'user_id': chat_row.user_id}
                 )
 
-        # Bulk-create missing tag rows for this chunk with proper display names.
-        if tag_display:
-            keys = list(tag_display.keys())
-            # One SELECT to find which (tag_id, user_id) pairs already exist.
-            existing: set = set()
-            # Parameterize via a VALUES / OR filter. Use a simple in-memory filter
-            # on the smaller side: we have <= CHUNK_SIZE tag keys. Split by
-            # user_id to keep predicates simple.
-            by_user: dict = {}
-            for tid, uid in keys:
-                by_user.setdefault(uid, set()).add(tid)
-            for uid, tids in by_user.items():
-                res = conn.execute(
-                    sa.select(tag.c.id, tag.c.user_id).where(
-                        tag.c.user_id == uid,
-                        tag.c.id.in_(tids),
-                    )
-                ).fetchall()
-                for r in res:
-                    existing.add((r.id, r.user_id))
+        if display_name_by_tag_key:
+            # One tuple-IN query covers every (tag_id, user_id) in the page,
+            # regardless of how many distinct users it spans. Both PG and
+            # SQLite >= 3.15 support row-value IN.
+            tag_keys = list(display_name_by_tag_key.keys())
+            existing_tag_keys: set[tuple[str, str]] = set()
+            existing_stmt = sa.select(tag.c.id, tag.c.user_id).where(
+                sa.tuple_(tag.c.id, tag.c.user_id).in_(tag_keys)
+            )
+            for existing_row in conn.execute(existing_stmt).fetchall():
+                existing_tag_keys.add((existing_row.id, existing_row.user_id))
 
             new_tag_rows = [
-                {
-                    'id': tid,
-                    'name': raw_name,
-                    'user_id': uid,
-                    'meta': None,
-                }
-                for (tid, uid), raw_name in tag_display.items()
-                if (tid, uid) not in existing
+                {'id': tid, 'name': raw_name, 'user_id': uid, 'meta': None}
+                for (tid, uid), raw_name in display_name_by_tag_key.items()
+                if (tid, uid) not in existing_tag_keys
             ]
             if new_tag_rows:
-                _bulk_insert_ignore(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
-                tags_queued += len(new_tag_rows)
+                _bulk_insert_skip_conflicts(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
+                tag_rows_queued += len(new_tag_rows)
 
-        # Bulk-insert chat_tag associations. Dedupe payload list first; duplicate
-        # PK collisions (e.g. re-run after partial failure) are swallowed by the
-        # dialect's conflict clause.
-        if assoc_rows:
-            unique_assocs = list(
-                {(r['chat_id'], r['tag_id'], r['user_id']): r for r in assoc_rows}.values()
+        if chat_tag_payload:
+            deduped_chat_tag_rows = list(
+                {
+                    (r['chat_id'], r['tag_id'], r['user_id']): r
+                    for r in chat_tag_payload
+                }.values()
             )
-            _bulk_insert_ignore(
-                conn, chat_tag, unique_assocs, conflict_cols=['chat_id', 'tag_id', 'user_id']
+            _bulk_insert_skip_conflicts(
+                conn, chat_tag, deduped_chat_tag_rows,
+                conflict_cols=['chat_id', 'tag_id', 'user_id'],
             )
-            assoc_queued += len(unique_assocs)
+            chat_tag_rows_queued += len(deduped_chat_tag_rows)
 
-        last_id = rows[-1].id
-        processed += len(rows)
+        last_chat_id = chat_rows[-1].id
+        chats_processed += len(chat_rows)
 
-        if processed >= next_log_at:
+        if chats_processed >= next_log_threshold:
             log.info(
-                f'chat_tag backfill progress: {processed} chats processed, '
-                f'{assoc_queued} associations queued, {tags_queued} tags queued, '
-                f'last_id={last_id}'
+                f'chat_tag backfill progress: {chats_processed} chats processed, '
+                f'{chat_tag_rows_queued} associations queued, '
+                f'{tag_rows_queued} tags queued, last_chat_id={last_chat_id}'
             )
-            next_log_at += LOG_EVERY
+            next_log_threshold += LOG_EVERY_CHATS
 
     log.info(
-        f'chat_tag backfill complete: {processed} chats processed, '
-        f'{assoc_queued} associations queued, {tags_queued} tags queued'
+        f'chat_tag backfill complete: {chats_processed} chats processed, '
+        f'{chat_tag_rows_queued} associations queued, {tag_rows_queued} tags queued'
     )
 
 
 def downgrade() -> None:
-    # NOTE: downgrade is only data-safe while chat.meta['tags'] is still being
-    # dual-written by the model layer. If a future migration drops the meta
-    # writes, update this downgrade to serialize chat_tag rows back into
-    # chat.meta['tags'] before dropping the table.
+    # TODO(chat-tag-meta-dropped): this downgrade relies on chat.meta['tags']
+    # still being dual-written. When a future migration drops those writes,
+    # this function must serialize chat_tag rows back into meta before the
+    # drop - or refuse to run.
     op.drop_index('chat_tag_chat_idx', table_name='chat_tag')
     op.drop_index('chat_tag_user_tag_idx', table_name='chat_tag')
     op.drop_table('chat_tag')

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -22,13 +22,12 @@ down_revision: Union[str, None] = 'e1f2a3b4c5d6'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# Keyset page size for the chat scan. Each page is drained with .fetchall()
-# so no server-side cursor stays open across pages.
+# Pages are drained with .fetchall() so no server-side cursor stays open
+# across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Cap rows per bulk INSERT so a page with many tags per chat can't push past
-# Postgres' 65,535 bind-parameter limit. chat_tag has 3 cols, tag has 4;
-# 5000 rows = 20,000 binds, well under the ceiling.
+# Keeps bulk INSERTs under Postgres' 65,535 bind-parameter limit even when
+# a page has many tags per chat.
 INSERT_BATCH_ROWS = 5000
 
 LOG_EVERY_CHATS = 50_000
@@ -84,8 +83,7 @@ def upgrade() -> None:
             ondelete='CASCADE',
         ),
     )
-    # Single secondary index covers the "list chats for this tag" path.
-    # A chat_id-only index would be redundant with the PK's leading column.
+    # chat_id-only lookups are covered by the PK's leading column.
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
 
     conn = op.get_bind()
@@ -126,8 +124,8 @@ def upgrade() -> None:
         if not chat_rows:
             break
 
-        # First raw display name seen per (tag_id, user_id) wins the name on
-        # any newly-created tag row. Pre-existing tag rows are never overwritten.
+        # First raw display name seen per (tag_id, user_id) wins for new rows;
+        # pre-existing tag rows are never overwritten.
         display_name_by_tag_key: dict[tuple[str, str], str] = {}
         chat_tag_payload: list[dict] = []
 
@@ -160,9 +158,7 @@ def upgrade() -> None:
                 )
 
         if display_name_by_tag_key:
-            # One tuple-IN query covers every (tag_id, user_id) in the page,
-            # regardless of how many distinct users it spans. PG and SQLite
-            # 3.15+ both support row-value IN.
+            # Row-value IN works on PG and SQLite >= 3.15.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
             existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
@@ -205,9 +201,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Serialize chat_tag rows back into chat.meta['tags'] before dropping the
-    # table. Post-upgrade the app stops writing meta['tags'], so skipping this
-    # step would silently discard every tag associated after the upgrade ran.
+    # Post-upgrade the app stops writing meta['tags'], so we must reserialize
+    # chat_tag back into meta before the drop or lose every post-upgrade tag.
     conn = op.get_bind()
 
     chat = sa.table(
@@ -232,8 +227,6 @@ def downgrade() -> None:
         )
         if last_chat_id is not None:
             tag_ids_by_chat_query = tag_ids_by_chat_query.where(chat_tag.c.chat_id > last_chat_id)
-        # Pull tags for up to CHAT_PAGE_SIZE chats per iteration. Rows come
-        # grouped by chat_id because of the ORDER BY.
         tag_ids_by_chat_query = tag_ids_by_chat_query.limit(CHAT_PAGE_SIZE * 50)
         rows = conn.execute(tag_ids_by_chat_query).fetchall()
         if not rows:
@@ -243,11 +236,8 @@ def downgrade() -> None:
         for row in rows:
             tag_ids_by_chat_id.setdefault(row.chat_id, []).append(row.tag_id)
 
-        # Only the first CHAT_PAGE_SIZE chat_ids in the batch are guaranteed
-        # to have their complete tag list - the last chat_id in `rows` may
-        # have been truncated mid-way. Write the completed ones, keep the
-        # last chat_id's tags for the next iteration by excluding it here
-        # and using `> chat_id` as the next cursor.
+        # The last chat_id in the batch may have been truncated mid-way
+        # through its tags, so defer it to the next iteration.
         chat_ids_in_order = list(tag_ids_by_chat_id.keys())
         if len(chat_ids_in_order) > 1:
             complete_chat_ids = chat_ids_in_order[:-1]

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -151,10 +151,16 @@ def upgrade() -> None:
             if not isinstance(meta, dict):
                 continue
 
+            # Shared-chat snapshots have user_id = 'shared-{orig_chat_id}' and
+            # historically carried meta['tags'] as a byproduct of the JSON
+            # blob copy. Don't promote those into real chat_tag / tag rows
+            # under the synthetic user_id; just strip the key for consistency.
+            is_shared_snapshot = isinstance(chat_row.user_id, str) and chat_row.user_id.startswith('shared-')
+
             raw_tag_names = meta.get('tags')
-            if not isinstance(raw_tag_names, list) or not raw_tag_names:
-                # Still strip the 'tags' key if present but empty/malformed,
-                # so meta is consistently tag-free post-upgrade.
+            if is_shared_snapshot or not isinstance(raw_tag_names, list) or not raw_tag_names:
+                # Still strip the 'tags' key if present, so meta is
+                # consistently tag-free post-upgrade.
                 if 'tags' in meta:
                     stripped_meta = {k: v for k, v in meta.items() if k != 'tags'}
                     meta_strip_payload.append(
@@ -235,6 +241,8 @@ def upgrade() -> None:
         f'{meta_rows_stripped} meta rows stripped'
     )
 
+    # Index built after backfill so bulk inserts don't pay index-maintenance
+    # cost per row.
     op.create_index('chat_tag_user_tag_idx', 'chat_tag', ['user_id', 'tag_id'])
 
 
@@ -321,6 +329,9 @@ def downgrade() -> None:
                     existing_meta = json.loads(existing_meta)
                 except (TypeError, ValueError):
                     existing_meta = {}
+            # Downgrade is lossy for originally-non-dict meta (replaced with {}).
+            # Upgrade already skipped such chats, so this only affects rows
+            # mutated post-upgrade.
             if not isinstance(existing_meta, dict):
                 existing_meta = {}
             # Skip chats that had no tags pre-upgrade and still have none:

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -12,6 +12,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql, sqlite
 
 log = logging.getLogger(__name__)
 
@@ -20,16 +21,53 @@ down_revision: Union[str, None] = 'e1f2a3b4c5d6'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# Keyset chunk size. Each chunk is fully materialized with .fetchall() before
-# the next query runs, so no server-side cursor stays open across chunks.
-# This avoids the OOM / cursor-timeout failures seen on very large Postgres
-# deployments when earlier migrations used yield_per streaming.
+# Keyset chunk size. Each chunk is fully materialized with .fetchall() and the
+# associated INSERTs run as bulk dialect-specific upserts, so no server-side
+# cursor stays open across chunks and no per-row savepoints are created.
+# Earlier migrations that used yield_per streaming held a single cursor for
+# the full run, which caused OOM / connection resets on large PostgreSQL
+# deployments.
 CHUNK_SIZE = 1000
 LOG_EVERY = 50_000
 
 
 def _normalize_tag_id(raw: str) -> str:
     return raw.replace(' ', '_').lower()
+
+
+def _bulk_insert_ignore(conn, table, rows, conflict_cols):
+    """Dialect-aware bulk INSERT that ignores duplicate key conflicts.
+
+    Postgres: INSERT ... ON CONFLICT (...) DO NOTHING.
+    SQLite:   INSERT OR IGNORE.
+    Other:    fall back to a portable INSERT inside a savepoint.
+    """
+    if not rows:
+        return
+    dialect = conn.dialect.name
+    if dialect == 'postgresql':
+        stmt = postgresql.insert(table).values(rows).on_conflict_do_nothing(index_elements=conflict_cols)
+        conn.execute(stmt)
+    elif dialect == 'sqlite':
+        stmt = sqlite.insert(table).values(rows).prefix_with('OR IGNORE')
+        conn.execute(stmt)
+    else:
+        # Portable fallback: wrap the bulk insert in a savepoint so a dup key
+        # doesn't poison the outer migration transaction.
+        sp = conn.begin_nested()
+        try:
+            conn.execute(sa.insert(table).values(rows))
+            sp.commit()
+        except Exception:
+            sp.rollback()
+            # Row-by-row fallback under savepoints.
+            for row in rows:
+                rp = conn.begin_nested()
+                try:
+                    conn.execute(sa.insert(table).values(**row))
+                    rp.commit()
+                except Exception:
+                    rp.rollback()
 
 
 def upgrade() -> None:
@@ -81,8 +119,9 @@ def upgrade() -> None:
 
     last_id: Union[str, None] = None
     processed = 0
-    assoc_inserted = 0
-    tags_created = 0
+    assoc_batched = 0
+    tags_batched = 0
+    next_log_at = LOG_EVERY
 
     while True:
         stmt = sa.select(chat.c.id, chat.c.user_id, chat.c.meta).order_by(chat.c.id)
@@ -90,21 +129,20 @@ def upgrade() -> None:
             stmt = stmt.where(chat.c.id > last_id)
         stmt = stmt.limit(CHUNK_SIZE)
 
-        # .fetchall() fully materializes and releases the cursor immediately.
-        # Do NOT switch to yield_per / stream_results here - holding a single
-        # server-side cursor open across a long backfill has caused OOM /
-        # connection resets on large PostgreSQL deployments.
+        # fetchall() fully materializes and releases the cursor immediately -
+        # see note at top of file on why this matters for large PG deployments.
         rows = conn.execute(stmt).fetchall()
         if not rows:
             break
 
-        known_tags_this_chunk: set = set()
+        # Collect the first raw display name seen per (tag_id, user_id) so
+        # freshly created tag rows keep the user's capitalization/spacing
+        # instead of the normalized id.
+        tag_display: dict[tuple, str] = {}
+        assoc_rows: list[dict] = []
 
         for row in rows:
-            chat_id = row.id
-            user_id = row.user_id
             meta = row.meta
-
             if isinstance(meta, str):
                 try:
                     meta = json.loads(meta)
@@ -126,67 +164,80 @@ def upgrade() -> None:
                     continue
                 seen_in_chat.add(tag_id)
 
-                tag_key = (tag_id, user_id)
-                if tag_key not in known_tags_this_chunk:
-                    sp = conn.begin_nested()
-                    try:
-                        exists = conn.execute(
-                            sa.select(tag.c.id).where(
-                                tag.c.id == tag_id,
-                                tag.c.user_id == user_id,
-                            )
-                        ).first()
-                        if exists is None:
-                            conn.execute(
-                                sa.insert(tag).values(
-                                    id=tag_id,
-                                    name=tag_id,
-                                    user_id=user_id,
-                                    meta=None,
-                                )
-                            )
-                            tags_created += 1
-                        sp.commit()
-                        known_tags_this_chunk.add(tag_key)
-                    except Exception as e:
-                        sp.rollback()
-                        log.warning(
-                            f'chat_tag backfill: ensure tag failed for ({tag_id}, {user_id}): {e}'
-                        )
-                        continue
+                tag_display.setdefault((tag_id, row.user_id), raw)
+                assoc_rows.append(
+                    {'chat_id': row.id, 'tag_id': tag_id, 'user_id': row.user_id}
+                )
 
-                sp = conn.begin_nested()
-                try:
-                    conn.execute(
-                        sa.insert(chat_tag).values(
-                            chat_id=chat_id,
-                            tag_id=tag_id,
-                            user_id=user_id,
-                        )
+        # Bulk-create missing tag rows for this chunk with proper display names.
+        if tag_display:
+            keys = list(tag_display.keys())
+            # One SELECT to find which (tag_id, user_id) pairs already exist.
+            existing: set = set()
+            # Parameterize via a VALUES / OR filter. Use a simple in-memory filter
+            # on the smaller side: we have <= CHUNK_SIZE tag keys. Split by
+            # user_id to keep predicates simple.
+            by_user: dict = {}
+            for tid, uid in keys:
+                by_user.setdefault(uid, set()).add(tid)
+            for uid, tids in by_user.items():
+                res = conn.execute(
+                    sa.select(tag.c.id, tag.c.user_id).where(
+                        tag.c.user_id == uid,
+                        tag.c.id.in_(tids),
                     )
-                    sp.commit()
-                    assoc_inserted += 1
-                except Exception:
-                    # Duplicate PK on re-run is expected and tolerated.
-                    sp.rollback()
+                ).fetchall()
+                for r in res:
+                    existing.add((r.id, r.user_id))
+
+            new_tag_rows = [
+                {
+                    'id': tid,
+                    'name': raw_name,
+                    'user_id': uid,
+                    'meta': None,
+                }
+                for (tid, uid), raw_name in tag_display.items()
+                if (tid, uid) not in existing
+            ]
+            if new_tag_rows:
+                _bulk_insert_ignore(conn, tag, new_tag_rows, conflict_cols=['id', 'user_id'])
+                tags_batched += len(new_tag_rows)
+
+        # Bulk-insert chat_tag associations. Dedupe payload list first; duplicate
+        # PK collisions (e.g. re-run after partial failure) are swallowed by the
+        # dialect's conflict clause.
+        if assoc_rows:
+            unique_assocs = list(
+                {(r['chat_id'], r['tag_id'], r['user_id']): r for r in assoc_rows}.values()
+            )
+            _bulk_insert_ignore(
+                conn, chat_tag, unique_assocs, conflict_cols=['chat_id', 'tag_id', 'user_id']
+            )
+            assoc_batched += len(unique_assocs)
 
         last_id = rows[-1].id
         processed += len(rows)
 
-        if processed // LOG_EVERY != (processed - len(rows)) // LOG_EVERY:
+        if processed >= next_log_at:
             log.info(
                 f'chat_tag backfill progress: {processed} chats processed, '
-                f'{assoc_inserted} associations inserted, {tags_created} tags created, '
+                f'{assoc_batched} associations queued, {tags_batched} tags queued, '
                 f'last_id={last_id}'
             )
+            next_log_at += LOG_EVERY
 
     log.info(
         f'chat_tag backfill complete: {processed} chats processed, '
-        f'{assoc_inserted} associations inserted, {tags_created} tags created'
+        f'{assoc_batched} associations queued, {tags_batched} tags queued'
     )
 
 
 def downgrade() -> None:
+    # NOTE: downgrade is only data-safe while chat.meta['tags'] is still being
+    # dual-written by the model layer. If a future migration drops the meta
+    # writes, update this downgrade to serialize chat_tag rows back into
+    # chat.meta['tags'] before dropping the table.
     op.drop_index('chat_tag_chat_idx', table_name='chat_tag')
     op.drop_index('chat_tag_user_tag_idx', table_name='chat_tag')
     op.drop_table('chat_tag')

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,8 +26,11 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Ceiling guard against Postgres' 65,535 bind-param statement limit.
-INSERT_BATCH_ROWS = 5000
+# Ceiling guard against each dialect's bind-parameter limit. PG allows
+# 65,535; SQLite < 3.32 (May 2020) caps at 999. Mirrors
+# open_webui.internal.db.sql_param_batch - keep in sync.
+SQL_PARAM_BATCH_PG = 5000
+SQL_PARAM_BATCH_SQLITE = 200
 
 LOG_EVERY_CHATS = 50_000
 
@@ -51,7 +54,8 @@ def _bulk_insert_on_conflict_nothing(conn, table, rows, index_elements):
     if not rows:
         return
     dialect = conn.dialect.name
-    for batch in _chunked(rows, INSERT_BATCH_ROWS):
+    batch_size = SQL_PARAM_BATCH_SQLITE if dialect == 'sqlite' else SQL_PARAM_BATCH_PG
+    for batch in _chunked(rows, batch_size):
         if dialect == 'postgresql':
             stmt = postgresql.insert(table).values(batch).on_conflict_do_nothing(index_elements=index_elements)
         elif dialect == 'sqlite':
@@ -189,12 +193,16 @@ def upgrade() -> None:
             )
 
         if display_name_by_tag_key:
-            # Row-value IN works on PG and SQLite >= 3.15. Chunked so a
-            # tenant-heavy page can't push this predicate past the PG bind
-            # param ceiling.
+            # Row-value IN works on PG and SQLite >= 3.15. Chunked per dialect
+            # to respect bind-param ceilings. The per-page reset of
+            # display_name_by_tag_key is safe because the existing-tag filter
+            # below skips (tag_id, user_id) pairs that already have a row,
+            # so a different display name seen on a later page can't clobber
+            # the first-seen name.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
-            for key_batch in _chunked(tag_keys, INSERT_BATCH_ROWS):
+            key_batch_size = SQL_PARAM_BATCH_SQLITE if dialect == 'sqlite' else SQL_PARAM_BATCH_PG
+            for key_batch in _chunked(tag_keys, key_batch_size):
                 existing_tag_query = sa.select(tag.c.id, tag.c.user_id).where(
                     sa.tuple_(tag.c.id, tag.c.user_id).in_(key_batch)
                 )

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -237,8 +237,9 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Reserialize chat_tag into meta['tags'] before the drop (post-upgrade
-    # writes only hit chat_tag). Lossy: rebuilt from tag_id (not tag.name)
-    # and in DB row order, not the original user-meaningful order.
+    # writes only hit chat_tag). Joins tag to recover tag.name so a
+    # round-trip upgrade -> downgrade preserves user-visible casing.
+    # Still lossy on row order (no user-meaningful order survives chat_tag).
     conn = op.get_bind()
     dialect = conn.dialect.name
     if dialect not in ('postgresql', 'sqlite'):
@@ -249,12 +250,20 @@ def downgrade() -> None:
     chat = sa.table(
         'chat',
         sa.column('id', sa.String()),
+        sa.column('user_id', sa.String()),
         sa.column('meta', sa.JSON()),
+    )
+    tag = sa.table(
+        'tag',
+        sa.column('id', sa.String()),
+        sa.column('name', sa.String()),
+        sa.column('user_id', sa.String()),
     )
     chat_tag = sa.table(
         'chat_tag',
         sa.column('chat_id', sa.String()),
         sa.column('tag_id', sa.String()),
+        sa.column('user_id', sa.String()),
     )
 
     last_chat_id: Union[str, None] = None
@@ -281,17 +290,25 @@ def downgrade() -> None:
         existing_meta_by_chat_id = {row.id: row.meta for row in page_rows}
 
         tag_rows = conn.execute(
-            sa.select(chat_tag.c.chat_id, chat_tag.c.tag_id).where(
-                chat_tag.c.chat_id.in_(chat_ids_in_page)
+            sa.select(chat_tag.c.chat_id, tag.c.name)
+            .select_from(
+                chat_tag.join(
+                    tag,
+                    sa.and_(
+                        chat_tag.c.tag_id == tag.c.id,
+                        chat_tag.c.user_id == tag.c.user_id,
+                    ),
+                )
             )
+            .where(chat_tag.c.chat_id.in_(chat_ids_in_page))
         ).fetchall()
-        tag_ids_by_chat_id: dict[str, list[str]] = {cid: [] for cid in chat_ids_in_page}
+        tag_names_by_chat_id: dict[str, list[str]] = {cid: [] for cid in chat_ids_in_page}
         for tag_row in tag_rows:
-            tag_ids_by_chat_id[tag_row.chat_id].append(tag_row.tag_id)
+            tag_names_by_chat_id[tag_row.chat_id].append(tag_row.name)
 
         update_params = []
         for chat_id in chat_ids_in_page:
-            tag_ids = tag_ids_by_chat_id[chat_id]
+            tag_names = tag_names_by_chat_id[chat_id]
             existing_meta = existing_meta_by_chat_id.get(chat_id)
             if isinstance(existing_meta, str):
                 try:
@@ -302,9 +319,9 @@ def downgrade() -> None:
                 existing_meta = {}
             # Skip chats that had no tags pre-upgrade and still have none:
             # don't grow their meta with an empty 'tags' key.
-            if not tag_ids and 'tags' not in existing_meta:
+            if not tag_names and 'tags' not in existing_meta:
                 continue
-            merged_meta = {**existing_meta, 'tags': tag_ids}
+            merged_meta = {**existing_meta, 'tags': tag_names}
             update_params.append({'target_chat_id': chat_id, 'new_meta': merged_meta})
 
         if update_params:

--- a/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
+++ b/backend/open_webui/migrations/versions/17a6d37e23d2_add_chat_tag_table.py
@@ -26,9 +26,7 @@ depends_on: Union[str, Sequence[str], None] = None
 # across pages (large PG deployments OOM'd on yield_per in prior migrations).
 CHAT_PAGE_SIZE = 1000
 
-# Per-statement bind-parameter budget per dialect. PG allows 65,535;
-# SQLite < 3.32 (May 2020) caps at 999. Mirrors
-# open_webui.internal.db._PG_MAX_BIND_PARAMS / _SQLITE_MAX_BIND_PARAMS.
+# Mirrors open_webui.internal.db budgets - keep in sync.
 _PG_MAX_BIND_PARAMS = 65_000
 _SQLITE_MAX_BIND_PARAMS = 900
 
@@ -160,10 +158,8 @@ def upgrade() -> None:
             if not isinstance(meta, dict):
                 continue
 
-            # Shared-chat snapshots have user_id = 'shared-{orig_chat_id}' and
-            # historically carried meta['tags'] as a byproduct of the JSON
-            # blob copy. Don't promote those into real chat_tag / tag rows
-            # under the synthetic user_id; just strip the key for consistency.
+            # Shared snapshots (user_id='shared-...') historically leaked tags
+            # via the meta blob; don't promote them to real associations.
             is_shared_snapshot = isinstance(chat_row.user_id, str) and chat_row.user_id.startswith('shared-')
 
             raw_tag_names = meta.get('tags')
@@ -198,12 +194,8 @@ def upgrade() -> None:
             )
 
         if display_name_by_tag_key:
-            # Row-value IN works on PG and SQLite >= 3.15. Chunked per dialect
-            # to respect bind-param ceilings. The per-page reset of
-            # display_name_by_tag_key is safe because the existing-tag filter
-            # below skips (tag_id, user_id) pairs that already have a row,
-            # so a different display name seen on a later page can't clobber
-            # the first-seen name.
+            # Per-page reset is safe: the existing-tag filter below never
+            # overwrites a pre-existing (tag_id, user_id) row.
             tag_keys = list(display_name_by_tag_key.keys())
             existing_tag_keys: set[tuple[str, str]] = set()
             # tuple_(id, user_id) = 2 binds per row.
@@ -343,9 +335,7 @@ def downgrade() -> None:
                     existing_meta = json.loads(existing_meta)
                 except (TypeError, ValueError):
                     existing_meta = {}
-            # Downgrade is lossy for originally-non-dict meta (replaced with {}).
-            # Upgrade already skipped such chats, so this only affects rows
-            # mutated post-upgrade.
+            # Lossy for originally-non-dict meta; upgrade skipped those rows.
             if not isinstance(existing_meta, dict):
                 existing_meta = {}
             # Skip chats that had no tags pre-upgrade and still have none:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -21,6 +21,8 @@ from sqlalchemy import (
     Boolean,
     Column,
     ForeignKey,
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
     String,
     Text,
     JSON,
@@ -67,6 +69,24 @@ class Chat(Base):
         Index('user_id_archived_idx', 'user_id', 'archived'),
         Index('updated_at_user_id_idx', 'updated_at', 'user_id'),
         Index('folder_id_user_id_idx', 'folder_id', 'user_id'),
+    )
+
+
+class ChatTag(Base):
+    __tablename__ = 'chat_tag'
+
+    chat_id = Column(String, nullable=False)
+    tag_id = Column(String, nullable=False)
+    user_id = Column(String, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint('chat_id', 'tag_id', 'user_id', name='pk_chat_tag'),
+        ForeignKeyConstraint(['chat_id'], ['chat.id'], name='fk_chat_tag_chat_id', ondelete='CASCADE'),
+        ForeignKeyConstraint(
+            ['tag_id', 'user_id'], ['tag.id', 'tag.user_id'], name='fk_chat_tag_tag', ondelete='CASCADE'
+        ),
+        Index('chat_tag_user_tag_idx', 'user_id', 'tag_id'),
+        Index('chat_tag_chat_idx', 'chat_id'),
     )
 
 
@@ -435,17 +455,22 @@ class ChatTable:
 
             old_tags = chat.meta.get('tags', [])
             new_tags = [t for t in tags if t.replace(' ', '_').lower() != 'none']
-            new_tag_ids = [t.replace(' ', '_').lower() for t in new_tags]
+            new_tag_ids = list(dict.fromkeys(t.replace(' ', '_').lower() for t in new_tags))
 
-            # Single meta update
             chat.meta = {**chat.meta, 'tags': new_tag_ids}
             await db.commit()
             await db.refresh(chat)
 
-            # Batch-create any missing tag rows
             await Tags.ensure_tags_exist(new_tags, user.id, db=db)
 
-            # Clean up orphaned old tags in one query
+            # Rewrite the normalized chat_tag association rows for this chat.
+            await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
+            if new_tag_ids:
+                db.add_all(
+                    [ChatTag(chat_id=id, tag_id=tag_id, user_id=user.id) for tag_id in new_tag_ids]
+                )
+            await db.commit()
+
             removed = set(old_tags) - set(new_tag_ids)
             if removed:
                 await self.delete_orphan_tags_for_user(list(removed), user.id, db=db)
@@ -1323,8 +1348,15 @@ class ChatTable:
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[TagModel]:
         async with get_async_db_context(db) as db:
-            chat = await db.get(Chat, id)
-            tag_ids = chat.meta.get('tags', [])
+            result = await db.execute(select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user_id))
+            tag_ids = [row[0] for row in result.all()]
+            if not tag_ids:
+                # Transitional fallback for chats whose normalized chat_tag rows
+                # haven't been populated yet (e.g. before the backfill migration
+                # ran for this chat's row, or data written by old code paths).
+                chat = await db.get(Chat, id)
+                if chat is not None:
+                    tag_ids = chat.meta.get('tags', []) or []
             return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
 
     async def get_chat_list_by_user_id_and_tag_name(
@@ -1336,26 +1368,14 @@ class ChatTable:
         db: Optional[AsyncSession] = None,
     ) -> list[ChatTitleIdResponse]:
         async with get_async_db_context(db) as db:
-            stmt = select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at).filter_by(
-                user_id=user_id
-            )
             tag_id = tag_name.replace(' ', '_').lower()
 
-            bind = await db.connection()
-            dialect_name = bind.dialect.name
-            log.info(f'DB dialect name: {dialect_name}')
-            if dialect_name == 'sqlite':
-                stmt = stmt.filter(
-                    text(f"EXISTS (SELECT 1 FROM json_each(Chat.meta, '$.tags') WHERE json_each.value = :tag_id)")
-                ).params(tag_id=tag_id)
-            elif dialect_name == 'postgresql':
-                stmt = stmt.filter(
-                    text("EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)")
-                ).params(tag_id=tag_id)
-            else:
-                raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
-
-            stmt = stmt.order_by(Chat.updated_at.desc(), Chat.id)
+            stmt = (
+                select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at)
+                .join(ChatTag, and_(ChatTag.chat_id == Chat.id, ChatTag.user_id == Chat.user_id))
+                .where(Chat.user_id == user_id, ChatTag.tag_id == tag_id)
+                .order_by(Chat.updated_at.desc(), Chat.id)
+            )
 
             if skip:
                 stmt = stmt.offset(skip)
@@ -1390,6 +1410,13 @@ class ChatTable:
                         **chat.meta,
                         'tags': list(set(chat.meta.get('tags', []) + [tag_id])),
                     }
+
+                existing = await db.execute(
+                    select(ChatTag).filter_by(chat_id=id, tag_id=tag_id, user_id=user_id)
+                )
+                if existing.scalar_one_or_none() is None:
+                    db.add(ChatTag(chat_id=id, tag_id=tag_id, user_id=user_id))
+
                 await db.commit()
                 await db.refresh(chat)
                 return ChatModel.model_validate(chat)
@@ -1400,24 +1427,14 @@ class ChatTable:
         self, tag_name: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> int:
         async with get_async_db_context(db) as db:
-            stmt = select(func.count(Chat.id)).filter_by(user_id=user_id, archived=False)
             tag_id = tag_name.replace(' ', '_').lower()
-
-            bind = await db.connection()
-            dialect_name = bind.dialect.name
-            if dialect_name == 'sqlite':
-                stmt = stmt.filter(
-                    text("EXISTS (SELECT 1 FROM json_each(Chat.meta, '$.tags') WHERE json_each.value = :tag_id)")
-                ).params(tag_id=tag_id)
-            elif dialect_name == 'postgresql':
-                stmt = stmt.filter(
-                    text("EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)")
-                ).params(tag_id=tag_id)
-            else:
-                raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
-
+            stmt = (
+                select(func.count(Chat.id))
+                .join(ChatTag, and_(ChatTag.chat_id == Chat.id, ChatTag.user_id == Chat.user_id))
+                .where(Chat.user_id == user_id, Chat.archived == False, ChatTag.tag_id == tag_id)  # noqa: E712
+            )
             result = await db.execute(stmt)
-            return result.scalar()
+            return result.scalar() or 0
 
     async def delete_orphan_tags_for_user(
         self,
@@ -1468,6 +1485,9 @@ class ChatTable:
                     **chat.meta,
                     'tags': list(set(tags)),
                 }
+                await db.execute(
+                    delete(ChatTag).filter_by(chat_id=id, tag_id=tag_id, user_id=user_id)
+                )
                 await db.commit()
                 return True
         except Exception:
@@ -1481,6 +1501,7 @@ class ChatTable:
                     **chat.meta,
                     'tags': [],
                 }
+                await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
                 await db.commit()
 
                 return True
@@ -1492,6 +1513,7 @@ class ChatTable:
             async with get_async_db_context(db) as db:
                 await db.execute(update(AutomationRun).filter_by(chat_id=id).values(chat_id=None))
                 await db.execute(delete(ChatMessage).filter_by(chat_id=id))
+                await db.execute(delete(ChatTag).filter_by(chat_id=id))
                 await db.execute(delete(Chat).filter_by(id=id))
                 await db.commit()
 
@@ -1504,6 +1526,7 @@ class ChatTable:
             async with get_async_db_context(db) as db:
                 await db.execute(update(AutomationRun).filter_by(chat_id=id).values(chat_id=None))
                 await db.execute(delete(ChatMessage).filter_by(chat_id=id))
+                await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
                 await db.execute(delete(Chat).filter_by(id=id, user_id=user_id))
                 await db.commit()
 
@@ -1525,6 +1548,7 @@ class ChatTable:
                 await db.execute(
                     delete(ChatMessage).filter(ChatMessage.chat_id.in_(select(Chat.id).filter_by(user_id=user_id)))
                 )
+                await db.execute(delete(ChatTag).filter_by(user_id=user_id))
                 await db.execute(delete(Chat).filter_by(user_id=user_id))
                 await db.commit()
 
@@ -1542,6 +1566,7 @@ class ChatTable:
                     update(AutomationRun).filter(AutomationRun.chat_id.in_(chat_ids_stmt)).values(chat_id=None)
                 )
                 await db.execute(delete(ChatMessage).filter(ChatMessage.chat_id.in_(chat_ids_stmt)))
+                await db.execute(delete(ChatTag).filter(ChatTag.chat_id.in_(chat_ids_stmt)))
                 await db.execute(delete(Chat).filter_by(user_id=user_id, folder_id=folder_id))
                 await db.commit()
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -530,9 +530,15 @@ class ChatTable:
                     db=db,
                     commit=False,
                 )
-                db.add_all(
-                    [ChatTag(chat_id=id, tag_id=tag_id, user_id=user.id) for tag_id in to_add]
-                )
+                # ON CONFLICT DO NOTHING per row so concurrent adds of the
+                # same (chat, tag, user) don't raise IntegrityError.
+                for tag_id in to_add:
+                    await insert_on_conflict_nothing(
+                        db,
+                        ChatTag,
+                        {'chat_id': id, 'tag_id': tag_id, 'user_id': user.id},
+                        index_elements=['chat_id', 'tag_id', 'user_id'],
+                    )
             if to_remove:
                 await db.execute(
                     delete(ChatTag).where(
@@ -1469,6 +1475,12 @@ class ChatTable:
                 if chat is None or chat.user_id != user_id:
                     return None
 
+                # Read the existing set before writing so we can build the
+                # response tag list in memory (avoids a post-commit round-trip).
+                existing_tag_ids = await self.get_chat_tag_ids_by_id_and_user_id(
+                    id, user_id, db=db
+                )
+
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
                 # ON CONFLICT DO NOTHING avoids a TOCTOU race on concurrent adds.
@@ -1482,10 +1494,8 @@ class ChatTable:
                 await db.commit()
 
                 response = ChatModel.model_validate(chat)
-                response.meta = {
-                    **(response.meta or {}),
-                    'tags': await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db),
-                }
+                merged_tag_ids = list(dict.fromkeys([*existing_tag_ids, tag_id]))
+                response.meta = {**(response.meta or {}), 'tags': merged_tag_ids}
                 return response
         except Exception as e:
             log.exception(f'add_chat_tag failed for chat={id} tag={tag_name}: {e}')
@@ -1515,8 +1525,9 @@ class ChatTable:
         threshold: int = 0,
         db: Optional[AsyncSession] = None,
     ) -> None:
-        """Delete tag rows from *tag_ids* whose non-archived chat reference
-        count for *user_id* is at most *threshold*.
+        """Delete tag rows from *tag_ids* whose chat reference count for
+        *user_id* is at most *threshold*. Counts across archived and
+        non-archived chats; see the in-body comment for why.
 
         threshold=0: call after a tag has already been removed from a chat.
         threshold=1: call before the referencing chat is deleted.

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -505,11 +505,15 @@ class ChatTable:
             return None
 
     async def update_chat_tags_by_id(self, id: str, tags: list[str], user) -> Optional[ChatModel]:
-        # Ownership check enforces the chat_tag.user_id == chat.user_id invariant.
-        # Concurrent calls on the same chat race on the previous_tag_ids read;
-        # last-writer-wins within a single call, set-union across races.
+        # Lock the chat row so concurrent callers see each other's chat_tag
+        # writes and the method has true replace semantics (instead of the
+        # set-union behavior a plain read + diff would produce under races).
+        # PG honors FOR UPDATE; SQLite is single-writer so the modifier is a
+        # no-op there.
         async with get_async_db_context() as db:
-            chat = await db.get(Chat, id)
+            chat = await db.scalar(
+                select(Chat).where(Chat.id == id).with_for_update()
+            )
             if chat is None or chat.user_id != user.id:
                 return None
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -575,7 +575,12 @@ class ChatTable:
             await db.commit()
 
             if to_remove:
-                await self.delete_orphan_tags_for_user(list(to_remove), user.id, db=db)
+                # Best-effort - runs after commit, so a failure here would
+                # only leave orphan tag rows (cosmetic), not corrupt state.
+                try:
+                    await self.delete_orphan_tags_for_user(list(to_remove), user.id, db=db)
+                except Exception:
+                    log.exception('orphan tag cleanup failed for chat=%s', id)
 
             return ChatModel.model_validate(chat)
 
@@ -722,6 +727,8 @@ class ChatTable:
     async def update_shared_chat_by_chat_id(
         self, chat_id: str, db: Optional[AsyncSession] = None
     ) -> Optional[ChatModel]:
+        # meta is still copied but no longer contains tags - see
+        # insert_shared_chat_by_chat_id for why tags don't propagate.
         try:
             async with get_async_db_context(db) as db:
                 chat = await db.get(Chat, chat_id)

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -9,12 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
 from open_webui.internal.db import (
-    SQL_PARAM_BATCH,
     Base,
     JSONField,
     get_async_db_context,
     insert_all_on_conflict_nothing,
     insert_on_conflict_nothing,
+    sql_param_batch,
 )
 from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id, RESERVED_TAG_ID_NONE
 from open_webui.models.folders import Folders
@@ -1434,11 +1434,11 @@ class ChatTable:
             return {}
         # Every chat_id is present in the result; callers can look up without .get().
         tag_ids_by_chat_id: dict[str, list[str]] = {chat_id: [] for chat_id in chat_ids}
-        # Chunk the IN predicate so a very large caller list can't push it
-        # past the Postgres 65,535 bind-param ceiling.
+        # Chunk the IN predicate to respect each dialect's bind-param ceiling.
         async with get_async_db_context(db) as db:
-            for start in range(0, len(chat_ids), SQL_PARAM_BATCH):
-                batch_ids = chat_ids[start:start + SQL_PARAM_BATCH]
+            batch_size = sql_param_batch(db.get_bind().dialect.name)
+            for start in range(0, len(chat_ids), batch_size):
+                batch_ids = chat_ids[start:start + batch_size]
                 rows = await db.execute(
                     select(ChatTag.chat_id, ChatTag.tag_id).where(
                         ChatTag.chat_id.in_(batch_ids),
@@ -1504,7 +1504,12 @@ class ChatTable:
             return None
         try:
             async with get_async_db_context(db) as db:
-                chat = await db.get(Chat, id)
+                # FOR UPDATE on the chat row to match update_chat_tags_by_id's
+                # lock, so a concurrent "set tags" + "add tag" pair on the same
+                # chat serializes rather than racing.
+                chat = await db.scalar(
+                    select(Chat).where(Chat.id == id).with_for_update()
+                )
                 # Ownership check enforces the chat_tag invariant.
                 if chat is None or chat.user_id != user_id:
                     return None

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
 from open_webui.internal.db import (
+    _INSERT_BATCH_ROWS,
     Base,
     JSONField,
     get_async_db_context,
@@ -570,8 +571,7 @@ class ChatTable:
                         ChatTag.tag_id.in_(to_remove),
                     )
                 )
-            if to_add or to_remove:
-                await db.commit()
+            await db.commit()
 
             if to_remove:
                 await self.delete_orphan_tags_for_user(list(to_remove), user.id, db=db)
@@ -681,6 +681,10 @@ class ChatTable:
     async def insert_shared_chat_by_chat_id(
         self, chat_id: str, db: Optional[AsyncSession] = None
     ) -> Optional[ChatModel]:
+        # Source chat's chat_tag rows are intentionally NOT copied to the
+        # shared scope. Pre-PR the origin's meta['tags'] was copied via the
+        # meta JSON blob; tags are personal organization metadata and don't
+        # belong on a public snapshot.
         async with get_async_db_context(db) as db:
             # Get the existing chat to share
             chat = await db.get(Chat, chat_id)
@@ -1426,19 +1430,23 @@ class ChatTable:
     async def get_chat_tag_ids_by_chat_ids_and_user_id(
         self, chat_ids: list[str], user_id: str, db: Optional[AsyncSession] = None
     ) -> dict[str, list[str]]:
+        if not chat_ids:
+            return {}
         # Every chat_id is present in the result; callers can look up without .get().
         tag_ids_by_chat_id: dict[str, list[str]] = {chat_id: [] for chat_id in chat_ids}
-        if not chat_ids:
-            return tag_ids_by_chat_id
+        # Chunk the IN predicate so a very large caller list can't push it
+        # past the Postgres 65,535 bind-param ceiling.
         async with get_async_db_context(db) as db:
-            rows = await db.execute(
-                select(ChatTag.chat_id, ChatTag.tag_id).where(
-                    ChatTag.chat_id.in_(chat_ids),
-                    ChatTag.user_id == user_id,
+            for start in range(0, len(chat_ids), _INSERT_BATCH_ROWS):
+                batch_ids = chat_ids[start:start + _INSERT_BATCH_ROWS]
+                rows = await db.execute(
+                    select(ChatTag.chat_id, ChatTag.tag_id).where(
+                        ChatTag.chat_id.in_(batch_ids),
+                        ChatTag.user_id == user_id,
+                    )
                 )
-            )
-            for chat_id, tag_id in rows.all():
-                tag_ids_by_chat_id[chat_id].append(tag_id)
+                for chat_id, tag_id in rows.all():
+                    tag_ids_by_chat_id[chat_id].append(tag_id)
         return tag_ids_by_chat_id
 
     async def get_chat_tags_by_id_and_user_id(

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -440,6 +440,9 @@ class ChatTable:
                 await Tags.ensure_tags_exist(
                     list(display_name_by_tag_id.values()), user_id, db=db, commit=False
                 )
+                # Flush so the tag rows hit the DB before chat_tag's composite
+                # FK is checked on the chat_tag flush at commit-time.
+                await db.flush()
             if new_chat_tag_rows:
                 db.add_all(new_chat_tag_rows)
             await db.commit()
@@ -528,8 +531,7 @@ class ChatTable:
                 if not tag_id or tag_id == RESERVED_TAG_ID_NONE:
                     continue
                 display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
-            new_tag_ids = list(display_name_by_tag_id.keys())
-            new_tag_ids_set = set(new_tag_ids)
+            new_tag_ids_set = set(display_name_by_tag_id)
 
             previous_tag_id_rows = await db.execute(
                 select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user.id)
@@ -745,7 +747,9 @@ class ChatTable:
 
     async def delete_shared_chat_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> bool:
         # ChatMessage / ChatTag deleted explicitly - see delete_chat_by_id
-        # NOTE re: SQLite PRAGMA foreign_keys.
+        # NOTE re: SQLite PRAGMA foreign_keys. The ChatTag delete is
+        # defensive: shared snapshots shouldn't have chat_tag rows, but
+        # clean up if any leaked in.
         try:
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Chat.id).filter_by(user_id=f'shared-{chat_id}'))

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -430,8 +430,11 @@ class ChatTable:
                         ChatTag(chat_id=chat_row.id, tag_id=tag_id, user_id=user_id)
                     )
 
-            # One commit covers chats + tag rows + chat_tag rows.
+            # One commit covers chats + tag rows + chat_tag rows. Flush the
+            # chat rows before raw tag/chat_tag inserts so the FKs resolve
+            # without depending on implicit autoflush ordering.
             db.add_all(chats)
+            await db.flush()
             if display_name_by_tag_id:
                 await Tags.ensure_tags_exist(
                     list(display_name_by_tag_id.values()), user_id, db=db, commit=False
@@ -728,6 +731,8 @@ class ChatTable:
             return None
 
     async def delete_shared_chat_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> bool:
+        # ChatMessage / ChatTag deleted explicitly - see delete_chat_by_id
+        # NOTE re: SQLite PRAGMA foreign_keys.
         try:
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Chat.id).filter_by(user_id=f'shared-{chat_id}'))
@@ -1534,18 +1539,12 @@ class ChatTable:
         if not tag_ids:
             return
         async with get_async_db_context(db) as db:
-            # Tag is orphan only if NO chat (archived or not) references it.
-            # Scoping this to non-archived would combine with the chat_tag FK
-            # CASCADE to destroy archived chats' associations the next time
-            # a non-archived chat drops the tag.
+            # Counts across archived + non-archived: scoping to non-archived
+            # would combine with the chat_tag FK CASCADE to destroy archived
+            # chats' associations the next time any chat drops the tag.
             reference_count_query = (
-                select(ChatTag.tag_id, func.count(Chat.id))
-                .join(Chat, Chat.id == ChatTag.chat_id)
-                .where(
-                    ChatTag.user_id == user_id,
-                    Chat.user_id == user_id,
-                    ChatTag.tag_id.in_(tag_ids),
-                )
+                select(ChatTag.tag_id, func.count())
+                .where(ChatTag.user_id == user_id, ChatTag.tag_id.in_(tag_ids))
                 .group_by(ChatTag.tag_id)
             )
             reference_count_by_tag_id = {

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -5,11 +5,12 @@ import uuid
 from typing import Optional
 
 from sqlalchemy import select, delete, update, func, or_, and_, text
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
 from open_webui.internal.db import Base, JSONField, get_async_db_context
-from open_webui.models.tags import TagModel, Tag, Tags
+from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.automations import AutomationRun
@@ -72,11 +73,11 @@ class Chat(Base):
     )
 
 
-# Replaces the denormalized chat.meta['tags'] JSON array. meta['tags'] is
-# still dual-written for rollback safety; remove in a follow-up migration
-# once revision 17a6d37e23d2 has rolled out everywhere. user_id in the PK is
-# redundant with chat_id (a chat has one owner) but enables the composite FK
-# to tag(id, user_id) and user-scoped queries without joining chat.
+# Source of truth for chat <-> tag associations as of revision 17a6d37e23d2.
+# Legacy chat.meta['tags'] data is preserved by that migration for rollback
+# serialization but is no longer read or written by the application.
+# user_id in the PK is redundant with chat_id (a chat has one owner) but
+# enables the composite FK to tag(id, user_id) and user-scoped queries.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -98,8 +99,8 @@ class ChatTag(Base):
             name='fk_chat_tag_tag',
             ondelete='CASCADE',
         ),
+        # chat_id-only lookups are covered by the PK's leading column.
         Index('chat_tag_user_tag_idx', 'user_id', 'tag_id'),
-        Index('chat_tag_chat_idx', 'chat_id'),
     )
 
 
@@ -389,16 +390,53 @@ class ChatTable:
         db: Optional[AsyncSession] = None,
     ) -> list[ChatModel]:
         async with get_async_db_context(db) as db:
-            chats = []
+            chats: list[Chat] = []
+            new_chat_tag_rows: list[ChatTag] = []
+            # First display name per normalized tag_id wins; avoids
+            # composite-PK duplicates inside ensure_tags_exist.
+            display_name_by_tag_id: dict[str, str] = {}
 
             for form_data in chat_import_forms:
-                chat = self._chat_import_form_to_chat_model(user_id, form_data)
-                chats.append(Chat(**chat.model_dump()))
+                chat_model = self._chat_import_form_to_chat_model(user_id, form_data)
 
+                # Pull tags out of the incoming meta and strip the key - tags
+                # now live in chat_tag, not in chat.meta.
+                raw_tag_names: list = []
+                if isinstance(chat_model.meta, dict) and 'tags' in chat_model.meta:
+                    candidate = chat_model.meta.get('tags')
+                    if isinstance(candidate, list):
+                        raw_tag_names = candidate
+                    chat_model.meta = {k: v for k, v in chat_model.meta.items() if k != 'tags'}
+
+                chat_row = Chat(**chat_model.model_dump())
+                chats.append(chat_row)
+
+                seen_tag_ids_in_chat: set[str] = set()
+                for raw_tag_name in raw_tag_names:
+                    if not isinstance(raw_tag_name, str):
+                        continue
+                    tag_id = normalize_tag_id(raw_tag_name)
+                    if not tag_id or tag_id in seen_tag_ids_in_chat:
+                        continue
+                    seen_tag_ids_in_chat.add(tag_id)
+                    display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
+                    new_chat_tag_rows.append(
+                        ChatTag(chat_id=chat_row.id, tag_id=tag_id, user_id=user_id)
+                    )
+
+            # Stage chats + tag rows + chat_tag rows, then commit once. A
+            # failure here rolls everything back so an imported chat never
+            # lands without its associations.
             db.add_all(chats)
+            if display_name_by_tag_id:
+                await Tags.ensure_tags_exist(
+                    list(display_name_by_tag_id.values()), user_id, db=db, commit=False
+                )
+            if new_chat_tag_rows:
+                db.add_all(new_chat_tag_rows)
             await db.commit()
 
-            # Dual-write messages to chat_message table
+            # Best-effort message dual-write (unchanged).
             try:
                 for form_data, chat_obj in zip(chat_import_forms, chats):
                     history = form_data.chat.get('history', {})
@@ -413,44 +451,6 @@ class ChatTable:
                             )
             except Exception as e:
                 log.warning(f'Failed to write imported messages to chat_message table: {e}')
-
-            # Dual-write meta['tags'] -> chat_tag so imported/cloned chats
-            # show up in tag-filtered lists. Chats are already committed;
-            # a failure here is logged and the unflushed tag/chat_tag work
-            # is rolled back.
-            try:
-                new_chat_tag_rows: list[ChatTag] = []
-                # First display name seen per normalized tag_id wins - avoids
-                # duplicate composite-PK inserts in ensure_tags_exist.
-                display_name_by_tag_id: dict[str, str] = {}
-                for chat_obj in chats:
-                    meta = chat_obj.meta or {}
-                    raw_tags = meta.get('tags') if isinstance(meta, dict) else None
-                    if not isinstance(raw_tags, list):
-                        continue
-                    seen_tag_ids_in_chat: set[str] = set()
-                    for raw_tag_name in raw_tags:
-                        if not isinstance(raw_tag_name, str):
-                            continue
-                        tag_id = raw_tag_name.replace(' ', '_').lower()
-                        if not tag_id or tag_id in seen_tag_ids_in_chat:
-                            continue
-                        seen_tag_ids_in_chat.add(tag_id)
-                        display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
-                        new_chat_tag_rows.append(
-                            ChatTag(chat_id=chat_obj.id, tag_id=tag_id, user_id=user_id)
-                        )
-                if display_name_by_tag_id:
-                    await Tags.ensure_tags_exist(
-                        list(display_name_by_tag_id.values()), user_id, db=db, commit=False
-                    )
-                if new_chat_tag_rows:
-                    db.add_all(new_chat_tag_rows)
-                if display_name_by_tag_id or new_chat_tag_rows:
-                    await db.commit()
-            except Exception as e:
-                await db.rollback()
-                log.error(f'Failed to write imported chat tags to chat_tag table: {e}')
 
             return [ChatModel.model_validate(chat) for chat in chats]
 
@@ -509,23 +509,20 @@ class ChatTable:
             # in ensure_tags_exist - both entries normalize to the same id.
             display_name_by_tag_id: dict[str, str] = {}
             for raw_tag_name in tags:
-                tag_id = raw_tag_name.replace(' ', '_').lower()
+                tag_id = normalize_tag_id(raw_tag_name)
                 if tag_id == 'none':
                     continue
                 display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
             new_tag_ids = list(display_name_by_tag_id.keys())
             new_tag_display_names = list(display_name_by_tag_id.values())
 
-            # Read previous tag ids from chat_tag (source of truth) so orphan
-            # cleanup is correct even if meta and chat_tag have drifted.
-            previous_tag_result = await db.execute(
+            previous_tag_id_rows = await db.execute(
                 select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user.id)
             )
-            previous_tag_ids = {row[0] for row in previous_tag_result.all()}
+            previous_tag_ids = {row[0] for row in previous_tag_id_rows.all()}
 
-            # meta, tag rows, and chat_tag rows commit in one transaction;
-            # commit=False keeps ensure_tags_exist from committing mid-batch.
-            chat.meta = {**chat.meta, 'tags': new_tag_ids}
+            # Tag rows + chat_tag rewrite commit together; commit=False keeps
+            # ensure_tags_exist from committing mid-batch.
             await Tags.ensure_tags_exist(new_tag_display_names, user.id, db=db, commit=False)
             await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
             if new_tag_ids:
@@ -1170,7 +1167,7 @@ class ChatTable:
 
         # search_text might contain 'tag:tag_name' format so we need to extract the tag_name
         tag_ids = [
-            word.replace('tag:', '').replace(' ', '_').lower() for word in search_text_words if word.startswith('tag:')
+            normalize_tag_id(word.removeprefix('tag:')) for word in search_text_words if word.startswith('tag:')
         ]
 
         # Extract folder names
@@ -1253,32 +1250,6 @@ class ChatTable:
                     )
                 )
 
-                # Check if there are any tags to filter
-                if 'none' in tag_ids:
-                    stmt = stmt.filter(
-                        text("""
-                            NOT EXISTS (
-                                SELECT 1
-                                FROM json_each(Chat.meta, '$.tags') AS tag
-                            )
-                            """)
-                    )
-                elif tag_ids:
-                    stmt = stmt.filter(
-                        and_(
-                            *[
-                                text(f"""
-                                    EXISTS (
-                                        SELECT 1
-                                        FROM json_each(Chat.meta, '$.tags') AS tag
-                                        WHERE tag.value = :tag_id_{tag_idx}
-                                    )
-                                    """).params(**{f'tag_id_{tag_idx}': tag_id})
-                                for tag_idx, tag_id in enumerate(tag_ids)
-                            ]
-                        )
-                    )
-
             elif dialect_name == 'postgresql':
                 # Safety filter: JSON field must not contain \u0000
                 stmt = stmt.filter(text("Chat.chat::text NOT LIKE '%\\\\u0000%'"))
@@ -1304,32 +1275,25 @@ class ChatTable:
                     )
                 ).params(title_key=f'%{search_text}%', content_key=search_text.lower())
 
-                if 'none' in tag_ids:
-                    stmt = stmt.filter(
-                        text("""
-                            NOT EXISTS (
-                                SELECT 1
-                                FROM json_array_elements_text(Chat.meta->'tags') AS tag
-                            )
-                            """)
-                    )
-                elif tag_ids:
-                    stmt = stmt.filter(
-                        and_(
-                            *[
-                                text(f"""
-                                    EXISTS (
-                                        SELECT 1
-                                        FROM json_array_elements_text(Chat.meta->'tags') AS tag
-                                        WHERE tag = :tag_id_{tag_idx}
-                                    )
-                                    """).params(**{f'tag_id_{tag_idx}': tag_id})
-                                for tag_idx, tag_id in enumerate(tag_ids)
-                            ]
-                        )
-                    )
             else:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
+
+            # Tag filter is dialect-agnostic now - chat_tag is a relational
+            # table. 'tag:none' = no associations; 'tag:X tag:Y' = has both.
+            if 'none' in tag_ids:
+                chat_has_any_tag = select(ChatTag.chat_id).where(
+                    ChatTag.chat_id == Chat.id,
+                    ChatTag.user_id == user_id,
+                )
+                stmt = stmt.filter(~exists(chat_has_any_tag))
+            else:
+                for required_tag_id in tag_ids:
+                    chat_has_this_tag = select(ChatTag.chat_id).where(
+                        ChatTag.chat_id == Chat.id,
+                        ChatTag.user_id == user_id,
+                        ChatTag.tag_id == required_tag_id,
+                    )
+                    stmt = stmt.filter(exists(chat_has_this_tag))
 
             # Perform pagination at the SQL level
             stmt = stmt.offset(skip).limit(limit)
@@ -1409,15 +1373,19 @@ class ChatTable:
         except Exception:
             return None
 
-    # Returns [] when the chat is missing or not owned by user_id - pre-PR
-    # code raised AttributeError on a missing chat.
+    # Returns [] for a missing/foreign chat - pre-PR code raised AttributeError.
+    async def get_chat_tag_ids_by_id_and_user_id(
+        self, id: str, user_id: str, db: Optional[AsyncSession] = None
+    ) -> list[str]:
+        async with get_async_db_context(db) as db:
+            rows = await db.execute(select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user_id))
+            return [row[0] for row in rows.all()]
+
     async def get_chat_tags_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[TagModel]:
-        async with get_async_db_context(db) as db:
-            result = await db.execute(select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user_id))
-            tag_ids = [row[0] for row in result.all()]
-            return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
+        tag_ids = await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db)
+        return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
 
     async def get_chat_list_by_user_id_and_tag_name(
         self,
@@ -1428,9 +1396,9 @@ class ChatTable:
         db: Optional[AsyncSession] = None,
     ) -> list[ChatTitleIdResponse]:
         async with get_async_db_context(db) as db:
-            tag_id = tag_name.replace(' ', '_').lower()
+            tag_id = normalize_tag_id(tag_name)
 
-            stmt = (
+            chat_list_query = (
                 select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at)
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
                 .where(
@@ -1442,12 +1410,11 @@ class ChatTable:
             )
 
             if skip:
-                stmt = stmt.offset(skip)
+                chat_list_query = chat_list_query.offset(skip)
             if limit:
-                stmt = stmt.limit(limit)
+                chat_list_query = chat_list_query.limit(limit)
 
-            result = await db.execute(stmt)
-            all_chats = result.all()
+            all_chats = (await db.execute(chat_list_query)).all()
             return [
                 ChatTitleIdResponse.model_validate(
                     {
@@ -1464,29 +1431,32 @@ class ChatTable:
     async def add_chat_tag_by_id_and_user_id_and_tag_name(
         self, id: str, user_id: str, tag_name: str, db: Optional[AsyncSession] = None
     ) -> Optional[ChatModel]:
-        tag_id = tag_name.replace(' ', '_').lower()
+        tag_id = normalize_tag_id(tag_name)
         try:
             async with get_async_db_context(db) as db:
                 chat = await db.get(Chat, id)
                 if chat is None:
                     return None
 
-                # commit=False - the single commit below covers tag, meta, and chat_tag.
+                # commit=False - single commit below covers tag + chat_tag.
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
-                if tag_id not in chat.meta.get('tags', []):
-                    chat.meta = {
-                        **chat.meta,
-                        'tags': list(dict.fromkeys(chat.meta.get('tags', []) + [tag_id])),
-                    }
-
-                has_assoc = await db.execute(
-                    select(ChatTag.chat_id).filter_by(
-                        chat_id=id, tag_id=tag_id, user_id=user_id
+                # ON CONFLICT DO NOTHING avoids a TOCTOU race between a
+                # check-first and the insert under concurrent adds.
+                bind = await db.connection()
+                dialect = bind.dialect.name
+                values = {'chat_id': id, 'tag_id': tag_id, 'user_id': user_id}
+                if dialect == 'postgresql':
+                    insert_chat_tag = postgresql.insert(ChatTag).values(**values)
+                elif dialect == 'sqlite':
+                    insert_chat_tag = sqlite.insert(ChatTag).values(**values)
+                else:
+                    raise NotImplementedError(f'unsupported dialect: {dialect}')
+                await db.execute(
+                    insert_chat_tag.on_conflict_do_nothing(
+                        index_elements=['chat_id', 'tag_id', 'user_id']
                     )
                 )
-                if has_assoc.first() is None:
-                    db.add(ChatTag(chat_id=id, tag_id=tag_id, user_id=user_id))
 
                 await db.commit()
                 await db.refresh(chat)
@@ -1498,8 +1468,8 @@ class ChatTable:
         self, tag_name: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> int:
         async with get_async_db_context(db) as db:
-            tag_id = tag_name.replace(' ', '_').lower()
-            stmt = (
+            tag_id = normalize_tag_id(tag_name)
+            chat_count_query = (
                 select(func.count(Chat.id))
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
                 .where(
@@ -1509,8 +1479,7 @@ class ChatTable:
                     Chat.archived.is_(False),
                 )
             )
-            result = await db.execute(stmt)
-            return result.scalar()
+            return (await db.execute(chat_count_query)).scalar()
 
     async def delete_orphan_tags_for_user(
         self,
@@ -1529,7 +1498,7 @@ class ChatTable:
             return
         async with get_async_db_context(db) as db:
             # One aggregate query replaces the former per-tag-id COUNT loop.
-            reference_counts_stmt = (
+            reference_count_query = (
                 select(ChatTag.tag_id, func.count(Chat.id))
                 .join(Chat, Chat.id == ChatTag.chat_id)
                 .where(
@@ -1540,9 +1509,8 @@ class ChatTable:
                 )
                 .group_by(ChatTag.tag_id)
             )
-            reference_count_by_tag_id = dict(
-                (row[0], row[1]) for row in (await db.execute(reference_counts_stmt)).all()
-            )
+            reference_count_rows = (await db.execute(reference_count_query)).all()
+            reference_count_by_tag_id = {row[0]: row[1] for row in reference_count_rows}
             orphan_tag_ids = [
                 tag_id
                 for tag_id in tag_ids
@@ -1565,15 +1533,7 @@ class ChatTable:
     ) -> bool:
         try:
             async with get_async_db_context(db) as db:
-                chat = await db.get(Chat, id)
-                tags = chat.meta.get('tags', [])
-                tag_id = tag_name.replace(' ', '_').lower()
-
-                tags = [tag for tag in tags if tag != tag_id]
-                chat.meta = {
-                    **chat.meta,
-                    'tags': list(set(tags)),
-                }
+                tag_id = normalize_tag_id(tag_name)
                 await db.execute(
                     delete(ChatTag).filter_by(chat_id=id, tag_id=tag_id, user_id=user_id)
                 )
@@ -1585,14 +1545,8 @@ class ChatTable:
     async def delete_all_tags_by_id_and_user_id(self, id: str, user_id: str, db: Optional[AsyncSession] = None) -> bool:
         try:
             async with get_async_db_context(db) as db:
-                chat = await db.get(Chat, id)
-                chat.meta = {
-                    **chat.meta,
-                    'tags': [],
-                }
                 await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
                 await db.commit()
-
                 return True
         except Exception:
             return False

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -95,7 +95,8 @@ class ChatTag(Base):
             name='fk_chat_tag_tag',
             ondelete='CASCADE',
         ),
-        # chat_id-only lookups are covered by the PK's leading column.
+        # No chat_id-only index: PK's leading column covers it. Name must
+        # match migration 17a6d37e23d2.
         Index('chat_tag_user_tag_idx', 'user_id', 'tag_id'),
     )
 
@@ -501,31 +502,47 @@ class ChatTable:
             # would otherwise hit a composite-PK error in ensure_tags_exist.
             display_name_by_tag_id: dict[str, str] = {}
             for raw_tag_name in tags:
+                if not isinstance(raw_tag_name, str):
+                    continue
                 tag_id = normalize_tag_id(raw_tag_name)
-                if tag_id == 'none':
+                if not tag_id or tag_id == 'none':
                     continue
                 display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
             new_tag_ids = list(display_name_by_tag_id.keys())
-            new_tag_display_names = list(display_name_by_tag_id.values())
+            new_tag_ids_set = set(new_tag_ids)
 
             previous_tag_id_rows = await db.execute(
                 select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user.id)
             )
             previous_tag_ids = {row[0] for row in previous_tag_id_rows.all()}
 
-            # commit=False keeps the tag ensure + chat_tag rewrite atomic.
-            await Tags.ensure_tags_exist(new_tag_display_names, user.id, db=db, commit=False)
-            await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
-            if new_tag_ids:
-                db.add_all(
-                    [ChatTag(chat_id=id, tag_id=tag_id, user_id=user.id) for tag_id in new_tag_ids]
+            to_add = new_tag_ids_set - previous_tag_ids
+            to_remove = previous_tag_ids - new_tag_ids_set
+
+            # commit=False keeps the tag ensure + chat_tag diff atomic.
+            if to_add:
+                await Tags.ensure_tags_exist(
+                    [display_name_by_tag_id[tag_id] for tag_id in to_add],
+                    user.id,
+                    db=db,
+                    commit=False,
                 )
+                db.add_all(
+                    [ChatTag(chat_id=id, tag_id=tag_id, user_id=user.id) for tag_id in to_add]
+                )
+            if to_remove:
+                await db.execute(
+                    delete(ChatTag).where(
+                        ChatTag.chat_id == id,
+                        ChatTag.user_id == user.id,
+                        ChatTag.tag_id.in_(to_remove),
+                    )
+                )
+            if to_add or to_remove:
+                await db.commit()
 
-            await db.commit()
-
-            removed_tag_ids = previous_tag_ids - set(new_tag_ids)
-            if removed_tag_ids:
-                await self.delete_orphan_tags_for_user(list(removed_tag_ids), user.id, db=db)
+            if to_remove:
+                await self.delete_orphan_tags_for_user(list(to_remove), user.id, db=db)
 
             # Response-only meta overlay for back-compat with ChatModel.meta.tags readers.
             response = ChatModel.model_validate(chat)
@@ -1274,19 +1291,19 @@ class ChatTable:
             # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
             # ChatTag.user_id filter is defense-in-depth + index alignment.
             if 'none' in tag_ids:
-                chat_has_any_tag = select(ChatTag.chat_id).where(
+                any_tag_subquery = select(ChatTag.chat_id).where(
                     ChatTag.chat_id == Chat.id,
                     ChatTag.user_id == user_id,
                 )
-                stmt = stmt.filter(~exists(chat_has_any_tag))
+                stmt = stmt.filter(~exists(any_tag_subquery))
             elif tag_ids:
                 for required_tag_id in tag_ids:
-                    chat_has_this_tag = select(ChatTag.chat_id).where(
+                    required_tag_subquery = select(ChatTag.chat_id).where(
                         ChatTag.chat_id == Chat.id,
                         ChatTag.user_id == user_id,
                         ChatTag.tag_id == required_tag_id,
                     )
-                    stmt = stmt.filter(exists(chat_has_this_tag))
+                    stmt = stmt.filter(exists(required_tag_subquery))
 
             # Perform pagination at the SQL level
             stmt = stmt.offset(skip).limit(limit)
@@ -1395,8 +1412,9 @@ class ChatTable:
     async def get_chat_tags_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[TagModel]:
-        tag_ids = await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db)
-        return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
+        async with get_async_db_context(db) as db:
+            tag_ids = await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db)
+            return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
 
     async def get_chat_list_by_user_id_and_tag_name(
         self,
@@ -1409,10 +1427,12 @@ class ChatTable:
         async with get_async_db_context(db) as db:
             tag_id = normalize_tag_id(tag_name)
 
+            # ChatTag.user_id filter is defense-in-depth + index alignment
+            # with chat_tag_user_tag_idx.
             chat_list_query = (
                 select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at)
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
-                .where(Chat.user_id == user_id, ChatTag.tag_id == tag_id)
+                .where(Chat.user_id == user_id, ChatTag.user_id == user_id, ChatTag.tag_id == tag_id)
                 .order_by(Chat.updated_at.desc(), Chat.id)
             )
 
@@ -1463,7 +1483,8 @@ class ChatTable:
                     'tags': await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db),
                 }
                 return response
-        except Exception:
+        except Exception as e:
+            log.exception(f'add_chat_tag failed for chat={id} tag={tag_name}: {e}')
             return None
 
     async def count_chats_by_tag_name_and_user_id(
@@ -1476,6 +1497,7 @@ class ChatTable:
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
                 .where(
                     Chat.user_id == user_id,
+                    ChatTag.user_id == user_id,
                     ChatTag.tag_id == tag_id,
                     Chat.archived.is_(False),
                 )
@@ -1502,14 +1524,16 @@ class ChatTable:
                 select(ChatTag.tag_id, func.count(Chat.id))
                 .join(Chat, Chat.id == ChatTag.chat_id)
                 .where(
+                    ChatTag.user_id == user_id,
                     Chat.user_id == user_id,
                     Chat.archived.is_(False),
                     ChatTag.tag_id.in_(tag_ids),
                 )
                 .group_by(ChatTag.tag_id)
             )
-            reference_count_rows = (await db.execute(reference_count_query)).all()
-            reference_count_by_tag_id = {row[0]: row[1] for row in reference_count_rows}
+            reference_count_by_tag_id = {
+                row[0]: row[1] for row in (await db.execute(reference_count_query)).all()
+            }
             orphan_tag_ids = [
                 tag_id
                 for tag_id in tag_ids
@@ -1573,7 +1597,7 @@ class ChatTable:
             async with get_async_db_context(db) as db:
                 await db.execute(update(AutomationRun).filter_by(chat_id=id).values(chat_id=None))
                 await db.execute(delete(ChatMessage).filter_by(chat_id=id))
-                await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
+                await db.execute(delete(ChatTag).filter_by(chat_id=id))
                 await db.execute(delete(Chat).filter_by(id=id, user_id=user_id))
                 await db.commit()
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -73,11 +73,8 @@ class Chat(Base):
     )
 
 
-# Source of truth for chat <-> tag associations as of revision 17a6d37e23d2.
-# Legacy chat.meta['tags'] data is preserved by that migration for rollback
-# serialization but is no longer read or written by the application.
-# user_id in the PK is redundant with chat_id (a chat has one owner) but
-# enables the composite FK to tag(id, user_id) and user-scoped queries.
+# user_id in the PK is redundant with chat_id but enables the composite FK
+# to tag(id, user_id) and user-scoped queries without joining chat.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -392,15 +389,14 @@ class ChatTable:
         async with get_async_db_context(db) as db:
             chats: list[Chat] = []
             new_chat_tag_rows: list[ChatTag] = []
-            # First display name per normalized tag_id wins; avoids
+            # First display name per normalized tag_id wins - avoids
             # composite-PK duplicates inside ensure_tags_exist.
             display_name_by_tag_id: dict[str, str] = {}
 
             for form_data in chat_import_forms:
                 chat_model = self._chat_import_form_to_chat_model(user_id, form_data)
 
-                # Pull tags out of the incoming meta and strip the key - tags
-                # now live in chat_tag, not in chat.meta.
+                # Tags now live in chat_tag, not meta.
                 raw_tag_names: list = []
                 if isinstance(chat_model.meta, dict) and 'tags' in chat_model.meta:
                     candidate = chat_model.meta.get('tags')
@@ -424,9 +420,7 @@ class ChatTable:
                         ChatTag(chat_id=chat_row.id, tag_id=tag_id, user_id=user_id)
                     )
 
-            # Stage chats + tag rows + chat_tag rows, then commit once. A
-            # failure here rolls everything back so an imported chat never
-            # lands without its associations.
+            # One commit covers chats + tag rows + chat_tag rows.
             db.add_all(chats)
             if display_name_by_tag_id:
                 await Tags.ensure_tags_exist(
@@ -436,7 +430,6 @@ class ChatTable:
                 db.add_all(new_chat_tag_rows)
             await db.commit()
 
-            # Best-effort message dual-write (unchanged).
             try:
                 for form_data, chat_obj in zip(chat_import_forms, chats):
                     history = form_data.chat.get('history', {})
@@ -504,9 +497,8 @@ class ChatTable:
             if chat is None:
                 return None
 
-            # Dedupe on normalized tag_id, first display name wins. Without
-            # this, ['My Tag', 'my tag'] hits a composite-PK IntegrityError
-            # in ensure_tags_exist - both entries normalize to the same id.
+            # First display name per normalized id wins; ['My Tag', 'my tag']
+            # would otherwise hit a composite-PK error in ensure_tags_exist.
             display_name_by_tag_id: dict[str, str] = {}
             for raw_tag_name in tags:
                 tag_id = normalize_tag_id(raw_tag_name)
@@ -521,8 +513,7 @@ class ChatTable:
             )
             previous_tag_ids = {row[0] for row in previous_tag_id_rows.all()}
 
-            # Tag rows + chat_tag rewrite commit together; commit=False keeps
-            # ensure_tags_exist from committing mid-batch.
+            # commit=False keeps the tag ensure + chat_tag rewrite atomic.
             await Tags.ensure_tags_exist(new_tag_display_names, user.id, db=db, commit=False)
             await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
             if new_tag_ids:
@@ -1278,8 +1269,7 @@ class ChatTable:
             else:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
 
-            # Tag filter is dialect-agnostic now - chat_tag is a relational
-            # table. 'tag:none' = no associations; 'tag:X tag:Y' = has both.
+            # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
             if 'none' in tag_ids:
                 chat_has_any_tag = select(ChatTag.chat_id).where(
                     ChatTag.chat_id == Chat.id,
@@ -1373,7 +1363,6 @@ class ChatTable:
         except Exception:
             return None
 
-    # Returns [] for a missing/foreign chat - pre-PR code raised AttributeError.
     async def get_chat_tag_ids_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[str]:
@@ -1438,11 +1427,9 @@ class ChatTable:
                 if chat is None:
                     return None
 
-                # commit=False - single commit below covers tag + chat_tag.
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
-                # ON CONFLICT DO NOTHING avoids a TOCTOU race between a
-                # check-first and the insert under concurrent adds.
+                # ON CONFLICT DO NOTHING avoids a TOCTOU race on concurrent adds.
                 bind = await db.connection()
                 dialect = bind.dialect.name
                 values = {'chat_id': id, 'tag_id': tag_id, 'user_id': user_id}
@@ -1497,7 +1484,6 @@ class ChatTable:
         if not tag_ids:
             return
         async with get_async_db_context(db) as db:
-            # One aggregate query replaces the former per-tag-id COUNT loop.
             reference_count_query = (
                 select(ChatTag.tag_id, func.count(Chat.id))
                 .join(Chat, Chat.id == ChatTag.chat_id)

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -395,7 +395,7 @@ class ChatTable:
     ) -> list[ChatModel]:
         async with get_async_db_context(db) as db:
             chats: list[Chat] = []
-            new_chat_tag_rows: list[ChatTag] = []
+            new_chat_tag_rows: list[dict] = []
             # First display name per normalized tag_id wins - avoids
             # composite-PK duplicates inside ensure_tags_exist.
             display_name_by_tag_id: dict[str, str] = {}
@@ -428,7 +428,7 @@ class ChatTable:
                     seen_tag_ids_in_chat.add(tag_id)
                     display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
                     new_chat_tag_rows.append(
-                        ChatTag(chat_id=chat_row.id, tag_id=tag_id, user_id=user_id)
+                        {'chat_id': chat_row.id, 'tag_id': tag_id, 'user_id': user_id}
                     )
 
             # One commit covers chats + tag rows + chat_tag rows. Flush the
@@ -443,7 +443,15 @@ class ChatTable:
                 # Flush so tag rows land before chat_tag's composite FK check.
                 await db.flush()
             if new_chat_tag_rows:
-                db.add_all(new_chat_tag_rows)
+                # ON CONFLICT DO NOTHING matches the other write paths; the
+                # per-chat seen set already dedupes within a single import,
+                # but this stays consistent and idempotent.
+                await insert_all_on_conflict_nothing(
+                    db,
+                    ChatTag,
+                    new_chat_tag_rows,
+                    index_elements=['chat_id', 'tag_id', 'user_id'],
+                )
             await db.commit()
 
             try:
@@ -752,8 +760,9 @@ class ChatTable:
             return None
 
     async def delete_shared_chat_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> bool:
-        # See delete_chat_by_id NOTE (SQLite PRAGMA). ChatTag delete is
-        # defensive - shared snapshots shouldn't have chat_tag rows.
+        # Explicit deletes for ChatMessage / ChatTag in case SQLite's FK
+        # cascade is disabled (PRAGMA foreign_keys). Shared snapshots aren't
+        # expected to carry chat_tag rows; this cleans up any that leaked.
         try:
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Chat.id).filter_by(user_id=f'shared-{chat_id}'))
@@ -1578,14 +1587,18 @@ class ChatTable:
             # Counts across archived + non-archived: scoping to non-archived
             # would combine with the chat_tag FK CASCADE to destroy archived
             # chats' associations the next time any chat drops the tag.
-            reference_count_query = (
-                select(ChatTag.tag_id, func.count())
-                .where(ChatTag.user_id == user_id, ChatTag.tag_id.in_(tag_ids))
-                .group_by(ChatTag.tag_id)
-            )
-            reference_count_by_tag_id = {
-                row[0]: row[1] for row in (await db.execute(reference_count_query)).all()
-            }
+            # Chunk the IN for consistency with other IN predicates in this PR.
+            reference_count_by_tag_id: dict[str, int] = {}
+            batch_size = sql_param_batch(db.get_bind().dialect.name, cols_per_row=1)
+            for start in range(0, len(tag_ids), batch_size):
+                batch = tag_ids[start:start + batch_size]
+                reference_count_query = (
+                    select(ChatTag.tag_id, func.count())
+                    .where(ChatTag.user_id == user_id, ChatTag.tag_id.in_(batch))
+                    .group_by(ChatTag.tag_id)
+                )
+                for tag_id, count in (await db.execute(reference_count_query)).all():
+                    reference_count_by_tag_id[tag_id] = count
             orphan_tag_ids = [
                 tag_id
                 for tag_id in tag_ids

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -5,11 +5,10 @@ import uuid
 from typing import Optional
 
 from sqlalchemy import select, delete, update, func, or_, and_, text
-from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, get_async_db_context, insert_ignore_conflict
 from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
@@ -522,7 +521,6 @@ class ChatTable:
                 )
 
             await db.commit()
-            await db.refresh(chat)
 
             removed_tag_ids = previous_tag_ids - set(new_tag_ids)
             if removed_tag_ids:
@@ -1271,16 +1269,12 @@ class ChatTable:
 
             # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
             if 'none' in tag_ids:
-                chat_has_any_tag = select(ChatTag.chat_id).where(
-                    ChatTag.chat_id == Chat.id,
-                    ChatTag.user_id == user_id,
-                )
+                chat_has_any_tag = select(ChatTag.chat_id).where(ChatTag.chat_id == Chat.id)
                 stmt = stmt.filter(~exists(chat_has_any_tag))
             else:
                 for required_tag_id in tag_ids:
                     chat_has_this_tag = select(ChatTag.chat_id).where(
                         ChatTag.chat_id == Chat.id,
-                        ChatTag.user_id == user_id,
                         ChatTag.tag_id == required_tag_id,
                     )
                     stmt = stmt.filter(exists(chat_has_this_tag))
@@ -1390,11 +1384,7 @@ class ChatTable:
             chat_list_query = (
                 select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at)
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
-                .where(
-                    Chat.user_id == user_id,
-                    ChatTag.user_id == user_id,
-                    ChatTag.tag_id == tag_id,
-                )
+                .where(Chat.user_id == user_id, ChatTag.tag_id == tag_id)
                 .order_by(Chat.updated_at.desc(), Chat.id)
             )
 
@@ -1430,23 +1420,14 @@ class ChatTable:
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
                 # ON CONFLICT DO NOTHING avoids a TOCTOU race on concurrent adds.
-                bind = await db.connection()
-                dialect = bind.dialect.name
-                values = {'chat_id': id, 'tag_id': tag_id, 'user_id': user_id}
-                if dialect == 'postgresql':
-                    insert_chat_tag = postgresql.insert(ChatTag).values(**values)
-                elif dialect == 'sqlite':
-                    insert_chat_tag = sqlite.insert(ChatTag).values(**values)
-                else:
-                    raise NotImplementedError(f'unsupported dialect: {dialect}')
-                await db.execute(
-                    insert_chat_tag.on_conflict_do_nothing(
-                        index_elements=['chat_id', 'tag_id', 'user_id']
-                    )
+                await insert_ignore_conflict(
+                    db,
+                    ChatTag,
+                    {'chat_id': id, 'tag_id': tag_id, 'user_id': user_id},
+                    conflict_cols=['chat_id', 'tag_id', 'user_id'],
                 )
 
                 await db.commit()
-                await db.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -1461,7 +1442,6 @@ class ChatTable:
                 .join(ChatTag, ChatTag.chat_id == Chat.id)
                 .where(
                     Chat.user_id == user_id,
-                    ChatTag.user_id == user_id,
                     ChatTag.tag_id == tag_id,
                     Chat.archived.is_(False),
                 )
@@ -1488,7 +1468,6 @@ class ChatTable:
                 select(ChatTag.tag_id, func.count(Chat.id))
                 .join(Chat, Chat.id == ChatTag.chat_id)
                 .where(
-                    ChatTag.user_id == user_id,
                     Chat.user_id == user_id,
                     Chat.archived.is_(False),
                     ChatTag.tag_id.in_(tag_ids),
@@ -1514,6 +1493,8 @@ class ChatTable:
             log.info(f"Count of chats for folder '{folder_id}': {count}")
             return count
 
+    # Callers that care about cleaning up now-unreferenced tag rows invoke
+    # delete_orphan_tags_for_user themselves (e.g. the DELETE /tags/all route).
     async def delete_tag_by_id_and_user_id_and_tag_name(
         self, id: str, user_id: str, tag_name: str, db: Optional[AsyncSession] = None
     ) -> bool:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -418,34 +418,37 @@ class ChatTable:
 
             # Dual-write tags from chat.meta['tags'] to chat_tag. Without this,
             # imported/cloned chats would have meta['tags'] set but no chat_tag
-            # rows, so they wouldn't appear in tag-filtered lists.
+            # rows, so they wouldn't appear in tag-filtered lists. Errors here
+            # leave meta['tags'] already committed but chat_tag unwritten;
+            # that divergence is what the log.error below alerts on.
             try:
                 tag_assocs: list[ChatTag] = []
-                raw_names_by_user: dict[str, list[str]] = {}
+                raw_names: set[str] = set()
                 for chat_obj in chats:
                     meta = chat_obj.meta or {}
                     raw_tags = meta.get('tags') if isinstance(meta, dict) else None
                     if not isinstance(raw_tags, list):
                         continue
-                    seen: set = set()
-                    for raw in raw_tags:
-                        if not isinstance(raw, str):
+                    seen_in_chat: set = set()
+                    for raw_tag_name in raw_tags:
+                        if not isinstance(raw_tag_name, str):
                             continue
-                        tid = raw.replace(' ', '_').lower()
-                        if not tid or tid in seen:
+                        tid = raw_tag_name.replace(' ', '_').lower()
+                        if not tid or tid in seen_in_chat:
                             continue
-                        seen.add(tid)
-                        raw_names_by_user.setdefault(user_id, []).append(raw)
+                        seen_in_chat.add(tid)
+                        raw_names.add(raw_tag_name)
                         tag_assocs.append(
                             ChatTag(chat_id=chat_obj.id, tag_id=tid, user_id=user_id)
                         )
-                for uid, names in raw_names_by_user.items():
-                    await Tags.ensure_tags_exist(names, uid, db=db)
+                if raw_names:
+                    await Tags.ensure_tags_exist(list(raw_names), user_id, db=db)
                 if tag_assocs:
                     db.add_all(tag_assocs)
                     await db.commit()
             except Exception as e:
-                log.warning(f'Failed to write imported chat tags to chat_tag table: {e}')
+                await db.rollback()
+                log.error(f'Failed to write imported chat tags to chat_tag table: {e}')
 
             return [ChatModel.model_validate(chat) for chat in chats]
 
@@ -499,17 +502,34 @@ class ChatTable:
             if chat is None:
                 return None
 
-            old_tags = chat.meta.get('tags', [])
-            new_tags = [t for t in tags if t.replace(' ', '_').lower() != 'none']
-            # Dedupe preserving order.
-            new_tag_ids = list(dict.fromkeys(t.replace(' ', '_').lower() for t in new_tags))
+            # Dedupe (id, display name) pairs together, keyed by the normalized
+            # id and keeping the first display name seen. Without this,
+            # callers passing ['My Tag', 'my tag'] would hit a composite-PK
+            # IntegrityError inside ensure_tags_exist because both entries
+            # normalize to the same tag id.
+            unique_by_id: dict[str, str] = {}
+            for raw in tags:
+                tag_id = raw.replace(' ', '_').lower()
+                if tag_id == 'none':
+                    continue
+                unique_by_id.setdefault(tag_id, raw)
+            new_tag_ids = list(unique_by_id.keys())
+            new_tag_names = list(unique_by_id.values())
+
+            # Source old tag ids from chat_tag (the new source of truth) so
+            # orphan cleanup stays correct even if meta and chat_tag have
+            # drifted for this row.
+            old_result = await db.execute(
+                select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user.id)
+            )
+            old_tag_ids = {row[0] for row in old_result.all()}
 
             # Write chat.meta and chat_tag rows atomically: a crash between the
             # meta update and the association rewrite would otherwise leave the
             # two stores disagreeing, and since chat_tag is now the source of
             # truth for list/count queries, that's a user-visible bug.
             chat.meta = {**chat.meta, 'tags': new_tag_ids}
-            await Tags.ensure_tags_exist(new_tags, user.id, db=db)
+            await Tags.ensure_tags_exist(new_tag_names, user.id, db=db)
             await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
             if new_tag_ids:
                 db.add_all(
@@ -519,7 +539,7 @@ class ChatTable:
             await db.commit()
             await db.refresh(chat)
 
-            removed = set(old_tags) - set(new_tag_ids)
+            removed = old_tag_ids - set(new_tag_ids)
             if removed:
                 await self.delete_orphan_tags_for_user(list(removed), user.id, db=db)
 
@@ -1444,11 +1464,17 @@ class ChatTable:
         tag_id = tag_name.replace(' ', '_').lower()
         try:
             async with get_async_db_context(db) as db:
+                # Check the chat exists before adding anything to the session -
+                # otherwise ensure_tags_exist would queue a tag row that no
+                # caller is going to use.
+                chat = await db.get(Chat, id)
+                if chat is None:
+                    return None
+
                 # Inside the same session so a failure below also rolls back
                 # any newly-created tag row.
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db)
 
-                chat = await db.get(Chat, id)
                 if tag_id not in chat.meta.get('tags', []):
                     chat.meta = {
                         **chat.meta,
@@ -1484,7 +1510,7 @@ class ChatTable:
                 .where(Chat.user_id == user_id, Chat.archived.is_(False), ChatTag.tag_id == tag_id)
             )
             result = await db.execute(stmt)
-            return result.scalar() or 0
+            return result.scalar()
 
     async def delete_orphan_tags_for_user(
         self,

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -9,14 +9,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
 from open_webui.internal.db import (
-    _INSERT_BATCH_ROWS,
+    SQL_PARAM_BATCH,
     Base,
     JSONField,
     get_async_db_context,
     insert_all_on_conflict_nothing,
     insert_on_conflict_nothing,
 )
-from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id
+from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id, RESERVED_TAG_ID_NONE
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.automations import AutomationRun
@@ -423,7 +423,7 @@ class ChatTable:
                     # 'none' is the sentinel used by the search "tag:none"
                     # filter to mean "no tags" - skip it so it never becomes
                     # a real association.
-                    if not tag_id or tag_id == 'none' or tag_id in seen_tag_ids_in_chat:
+                    if not tag_id or tag_id == RESERVED_TAG_ID_NONE or tag_id in seen_tag_ids_in_chat:
                         continue
                     seen_tag_ids_in_chat.add(tag_id)
                     display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
@@ -525,7 +525,7 @@ class ChatTable:
                 if not isinstance(raw_tag_name, str):
                     continue
                 tag_id = normalize_tag_id(raw_tag_name)
-                if not tag_id or tag_id == 'none':
+                if not tag_id or tag_id == RESERVED_TAG_ID_NONE:
                     continue
                 display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
             new_tag_ids = list(display_name_by_tag_id.keys())
@@ -1325,7 +1325,7 @@ class ChatTable:
 
             # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
             # ChatTag.user_id filter is defense-in-depth + index alignment.
-            if 'none' in tag_ids:
+            if RESERVED_TAG_ID_NONE in tag_ids:
                 any_tag_subquery = select(ChatTag.chat_id).where(
                     ChatTag.chat_id == Chat.id,
                     ChatTag.user_id == user_id,
@@ -1437,8 +1437,8 @@ class ChatTable:
         # Chunk the IN predicate so a very large caller list can't push it
         # past the Postgres 65,535 bind-param ceiling.
         async with get_async_db_context(db) as db:
-            for start in range(0, len(chat_ids), _INSERT_BATCH_ROWS):
-                batch_ids = chat_ids[start:start + _INSERT_BATCH_ROWS]
+            for start in range(0, len(chat_ids), SQL_PARAM_BATCH):
+                batch_ids = chat_ids[start:start + SQL_PARAM_BATCH]
                 rows = await db.execute(
                     select(ChatTag.chat_id, ChatTag.tag_id).where(
                         ChatTag.chat_id.in_(batch_ids),
@@ -1500,7 +1500,7 @@ class ChatTable:
     ) -> Optional[ChatModel]:
         tag_id = normalize_tag_id(tag_name)
         # 'none' is the search sentinel; '' would bind a garbage association.
-        if not tag_id or tag_id == 'none':
+        if not tag_id or tag_id == RESERVED_TAG_ID_NONE:
             return None
         try:
             async with get_async_db_context(db) as db:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -72,10 +72,8 @@ class Chat(Base):
     )
 
 
-# Invariant (enforced by writers, not by the schema): chat_tag.user_id equals
-# chat(chat_id).user_id. user_id is kept in the PK so the composite FK to
-# tag(id, user_id) is declarable - SQL can't reference just part of a
-# composite PK on the parent side.
+# Writer-enforced invariant: chat_tag.user_id == chat(chat_id).user_id.
+# user_id is in the PK so the composite FK to tag(id, user_id) is declarable.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -529,9 +527,7 @@ class ChatTable:
             if removed_tag_ids:
                 await self.delete_orphan_tags_for_user(list(removed_tag_ids), user.id, db=db)
 
-            # Overlay the new tag ids on the response only - chat.meta is
-            # no longer the source of truth, but existing clients may still
-            # read ChatModel.meta['tags'].
+            # Response-only meta overlay for back-compat with ChatModel.meta.tags readers.
             response = ChatModel.model_validate(chat)
             response.meta = {**(response.meta or {}), 'tags': new_tag_ids}
             return response
@@ -1276,9 +1272,7 @@ class ChatTable:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
 
             # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
-            # The ChatTag.user_id predicate is redundant with the writer-enforced
-            # invariant, but keeping it defends against any future drift and
-            # drives the chat_tag_user_tag_idx lookup.
+            # ChatTag.user_id filter is defense-in-depth + index alignment.
             if 'none' in tag_ids:
                 chat_has_any_tag = select(ChatTag.chat_id).where(
                     ChatTag.chat_id == Chat.id,
@@ -1383,11 +1377,7 @@ class ChatTable:
     async def get_chat_tag_ids_by_chat_ids_and_user_id(
         self, chat_ids: list[str], user_id: str, db: Optional[AsyncSession] = None
     ) -> dict[str, list[str]]:
-        """Batch equivalent of get_chat_tag_ids_by_id_and_user_id.
-
-        Every chat_id from *chat_ids* is present in the result (empty list if
-        no tags), so callers can look up without a .get() default.
-        """
+        # Every chat_id is present in the result; callers can look up without .get().
         tag_ids_by_chat_id: dict[str, list[str]] = {chat_id: [] for chat_id in chat_ids}
         if not chat_ids:
             return tag_ids_by_chat_id

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -493,9 +493,12 @@ class ChatTable:
             return None
 
     async def update_chat_tags_by_id(self, id: str, tags: list[str], user) -> Optional[ChatModel]:
+        # Ownership check enforces the chat_tag.user_id == chat.user_id invariant.
+        # Concurrent calls on the same chat race on the previous_tag_ids read;
+        # last-writer-wins within a single call, set-union across races.
         async with get_async_db_context() as db:
             chat = await db.get(Chat, id)
-            if chat is None:
+            if chat is None or chat.user_id != user.id:
                 return None
 
             # First display name per normalized id wins; ['My Tag', 'my tag']
@@ -1462,7 +1465,8 @@ class ChatTable:
         try:
             async with get_async_db_context(db) as db:
                 chat = await db.get(Chat, id)
-                if chat is None:
+                # Ownership check enforces the chat_tag invariant.
+                if chat is None or chat.user_id != user_id:
                     return None
 
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
@@ -1520,13 +1524,16 @@ class ChatTable:
         if not tag_ids:
             return
         async with get_async_db_context(db) as db:
+            # Tag is orphan only if NO chat (archived or not) references it.
+            # Scoping this to non-archived would combine with the chat_tag FK
+            # CASCADE to destroy archived chats' associations the next time
+            # a non-archived chat drops the tag.
             reference_count_query = (
                 select(ChatTag.tag_id, func.count(Chat.id))
                 .join(Chat, Chat.id == ChatTag.chat_id)
                 .where(
                     ChatTag.user_id == user_id,
                     Chat.user_id == user_id,
-                    Chat.archived.is_(False),
                     ChatTag.tag_id.in_(tag_ids),
                 )
                 .group_by(ChatTag.tag_id)
@@ -1564,7 +1571,8 @@ class ChatTable:
                 )
                 await db.commit()
                 return True
-        except Exception:
+        except Exception as e:
+            log.exception(f'delete_tag failed for chat={id} tag={tag_name}: {e}')
             return False
 
     async def delete_all_tags_by_id_and_user_id(self, id: str, user_id: str, db: Optional[AsyncSession] = None) -> bool:
@@ -1573,7 +1581,8 @@ class ChatTable:
                 await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
                 await db.commit()
                 return True
-        except Exception:
+        except Exception as e:
+            log.exception(f'delete_all_tags failed for chat={id}: {e}')
             return False
 
     # NOTE: ChatMessage / ChatTag are deleted explicitly - SQLite only
@@ -1619,6 +1628,7 @@ class ChatTable:
                 await db.execute(
                     delete(ChatMessage).filter(ChatMessage.chat_id.in_(select(Chat.id).filter_by(user_id=user_id)))
                 )
+                # Relies on chat_tag.user_id == chat.user_id invariant.
                 await db.execute(delete(ChatTag).filter_by(user_id=user_id))
                 await db.execute(delete(Chat).filter_by(user_id=user_id))
                 await db.commit()

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -538,6 +538,11 @@ class ChatTable:
             to_add = new_tag_ids_set - previous_tag_ids
             to_remove = previous_tag_ids - new_tag_ids_set
 
+            # Nothing changed - release the FOR UPDATE lock without committing
+            # mid-batch work that doesn't exist.
+            if not to_add and not to_remove:
+                return ChatModel.model_validate(chat)
+
             # commit=False keeps the tag ensure + chat_tag diff atomic.
             if to_add:
                 await Tags.ensure_tags_exist(
@@ -1486,6 +1491,9 @@ class ChatTable:
         self, id: str, user_id: str, tag_name: str, db: Optional[AsyncSession] = None
     ) -> Optional[ChatModel]:
         tag_id = normalize_tag_id(tag_name)
+        # 'none' is the search sentinel; '' would bind a garbage association.
+        if not tag_id or tag_id == 'none':
+            return None
         try:
             async with get_async_db_context(db) as db:
                 chat = await db.get(Chat, id)
@@ -1509,6 +1517,9 @@ class ChatTable:
             log.exception('add_chat_tag failed for chat=%s tag=%s', id, tag_name)
             return None
 
+    # UI-facing count: excludes archived chats, so a tag with only archived
+    # references shows count=0 but isn't treated as orphan by
+    # delete_orphan_tags_for_user (which intentionally counts archived too).
     async def count_chats_by_tag_name_and_user_id(
         self, tag_name: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> int:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -72,13 +72,11 @@ class Chat(Base):
     )
 
 
-# Normalized chat/tag association. Introduced to replace the denormalized
-# chat.meta['tags'] JSON array; meta['tags'] is still dual-written for
-# rollback safety and should be removed in a follow-up migration once all
-# deployments are past revision 17a6d37e23d2. When that happens, remove the
-# meta['tags'] writes in the methods below and switch any remaining readers
-# (e.g. the tag filters in get_chats_by_user_id_and_search_text) to join
-# ChatTag instead of scanning JSON.
+# Replaces the denormalized chat.meta['tags'] JSON array. meta['tags'] is
+# still dual-written for rollback safety; remove in a follow-up migration
+# once revision 17a6d37e23d2 has rolled out everywhere. user_id in the PK is
+# redundant with chat_id (a chat has one owner) but enables the composite FK
+# to tag(id, user_id) and user-scoped queries without joining chat.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -416,35 +414,39 @@ class ChatTable:
             except Exception as e:
                 log.warning(f'Failed to write imported messages to chat_message table: {e}')
 
-            # Dual-write tags from chat.meta['tags'] to chat_tag. Without this,
-            # imported/cloned chats would have meta['tags'] set but no chat_tag
-            # rows, so they wouldn't appear in tag-filtered lists. Errors here
-            # leave meta['tags'] already committed but chat_tag unwritten;
-            # that divergence is what the log.error below alerts on.
+            # Dual-write meta['tags'] -> chat_tag so imported/cloned chats
+            # show up in tag-filtered lists. Chats are already committed;
+            # a failure here is logged and the unflushed tag/chat_tag work
+            # is rolled back.
             try:
-                tag_assocs: list[ChatTag] = []
-                raw_names: set[str] = set()
+                new_chat_tag_rows: list[ChatTag] = []
+                # First display name seen per normalized tag_id wins - avoids
+                # duplicate composite-PK inserts in ensure_tags_exist.
+                display_name_by_tag_id: dict[str, str] = {}
                 for chat_obj in chats:
                     meta = chat_obj.meta or {}
                     raw_tags = meta.get('tags') if isinstance(meta, dict) else None
                     if not isinstance(raw_tags, list):
                         continue
-                    seen_in_chat: set = set()
+                    seen_tag_ids_in_chat: set[str] = set()
                     for raw_tag_name in raw_tags:
                         if not isinstance(raw_tag_name, str):
                             continue
-                        tid = raw_tag_name.replace(' ', '_').lower()
-                        if not tid or tid in seen_in_chat:
+                        tag_id = raw_tag_name.replace(' ', '_').lower()
+                        if not tag_id or tag_id in seen_tag_ids_in_chat:
                             continue
-                        seen_in_chat.add(tid)
-                        raw_names.add(raw_tag_name)
-                        tag_assocs.append(
-                            ChatTag(chat_id=chat_obj.id, tag_id=tid, user_id=user_id)
+                        seen_tag_ids_in_chat.add(tag_id)
+                        display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
+                        new_chat_tag_rows.append(
+                            ChatTag(chat_id=chat_obj.id, tag_id=tag_id, user_id=user_id)
                         )
-                if raw_names:
-                    await Tags.ensure_tags_exist(list(raw_names), user_id, db=db)
-                if tag_assocs:
-                    db.add_all(tag_assocs)
+                if display_name_by_tag_id:
+                    await Tags.ensure_tags_exist(
+                        list(display_name_by_tag_id.values()), user_id, db=db, commit=False
+                    )
+                if new_chat_tag_rows:
+                    db.add_all(new_chat_tag_rows)
+                if display_name_by_tag_id or new_chat_tag_rows:
                     await db.commit()
             except Exception as e:
                 await db.rollback()
@@ -502,34 +504,29 @@ class ChatTable:
             if chat is None:
                 return None
 
-            # Dedupe (id, display name) pairs together, keyed by the normalized
-            # id and keeping the first display name seen. Without this,
-            # callers passing ['My Tag', 'my tag'] would hit a composite-PK
-            # IntegrityError inside ensure_tags_exist because both entries
-            # normalize to the same tag id.
-            unique_by_id: dict[str, str] = {}
-            for raw in tags:
-                tag_id = raw.replace(' ', '_').lower()
+            # Dedupe on normalized tag_id, first display name wins. Without
+            # this, ['My Tag', 'my tag'] hits a composite-PK IntegrityError
+            # in ensure_tags_exist - both entries normalize to the same id.
+            display_name_by_tag_id: dict[str, str] = {}
+            for raw_tag_name in tags:
+                tag_id = raw_tag_name.replace(' ', '_').lower()
                 if tag_id == 'none':
                     continue
-                unique_by_id.setdefault(tag_id, raw)
-            new_tag_ids = list(unique_by_id.keys())
-            new_tag_names = list(unique_by_id.values())
+                display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
+            new_tag_ids = list(display_name_by_tag_id.keys())
+            new_tag_display_names = list(display_name_by_tag_id.values())
 
-            # Source old tag ids from chat_tag (the new source of truth) so
-            # orphan cleanup stays correct even if meta and chat_tag have
-            # drifted for this row.
-            old_result = await db.execute(
+            # Read previous tag ids from chat_tag (source of truth) so orphan
+            # cleanup is correct even if meta and chat_tag have drifted.
+            previous_tag_result = await db.execute(
                 select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user.id)
             )
-            old_tag_ids = {row[0] for row in old_result.all()}
+            previous_tag_ids = {row[0] for row in previous_tag_result.all()}
 
-            # Write chat.meta and chat_tag rows atomically: a crash between the
-            # meta update and the association rewrite would otherwise leave the
-            # two stores disagreeing, and since chat_tag is now the source of
-            # truth for list/count queries, that's a user-visible bug.
+            # meta, tag rows, and chat_tag rows commit in one transaction;
+            # commit=False keeps ensure_tags_exist from committing mid-batch.
             chat.meta = {**chat.meta, 'tags': new_tag_ids}
-            await Tags.ensure_tags_exist(new_tag_names, user.id, db=db)
+            await Tags.ensure_tags_exist(new_tag_display_names, user.id, db=db, commit=False)
             await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
             if new_tag_ids:
                 db.add_all(
@@ -539,9 +536,9 @@ class ChatTable:
             await db.commit()
             await db.refresh(chat)
 
-            removed = old_tag_ids - set(new_tag_ids)
-            if removed:
-                await self.delete_orphan_tags_for_user(list(removed), user.id, db=db)
+            removed_tag_ids = previous_tag_ids - set(new_tag_ids)
+            if removed_tag_ids:
+                await self.delete_orphan_tags_for_user(list(removed_tag_ids), user.id, db=db)
 
             return ChatModel.model_validate(chat)
 
@@ -709,12 +706,12 @@ class ChatTable:
     async def delete_shared_chat_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> bool:
         try:
             async with get_async_db_context(db) as db:
-                # Get shared chat IDs
                 result = await db.execute(select(Chat.id).filter_by(user_id=f'shared-{chat_id}'))
                 shared_ids = [row[0] for row in result.all()]
 
                 if shared_ids:
                     await db.execute(delete(ChatMessage).filter(ChatMessage.chat_id.in_(shared_ids)))
+                    await db.execute(delete(ChatTag).filter(ChatTag.chat_id.in_(shared_ids)))
                     await db.execute(delete(Chat).filter_by(user_id=f'shared-{chat_id}'))
                     await db.commit()
 
@@ -1412,6 +1409,8 @@ class ChatTable:
         except Exception:
             return None
 
+    # Returns [] when the chat is missing or not owned by user_id - pre-PR
+    # code raised AttributeError on a missing chat.
     async def get_chat_tags_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[TagModel]:
@@ -1433,8 +1432,12 @@ class ChatTable:
 
             stmt = (
                 select(Chat.id, Chat.title, Chat.updated_at, Chat.created_at, Chat.last_read_at)
-                .join(ChatTag, and_(ChatTag.chat_id == Chat.id, ChatTag.user_id == Chat.user_id))
-                .where(Chat.user_id == user_id, ChatTag.tag_id == tag_id)
+                .join(ChatTag, ChatTag.chat_id == Chat.id)
+                .where(
+                    Chat.user_id == user_id,
+                    ChatTag.user_id == user_id,
+                    ChatTag.tag_id == tag_id,
+                )
                 .order_by(Chat.updated_at.desc(), Chat.id)
             )
 
@@ -1464,21 +1467,16 @@ class ChatTable:
         tag_id = tag_name.replace(' ', '_').lower()
         try:
             async with get_async_db_context(db) as db:
-                # Check the chat exists before adding anything to the session -
-                # otherwise ensure_tags_exist would queue a tag row that no
-                # caller is going to use.
                 chat = await db.get(Chat, id)
                 if chat is None:
                     return None
 
-                # Inside the same session so a failure below also rolls back
-                # any newly-created tag row.
-                await Tags.ensure_tags_exist([tag_name], user_id, db=db)
+                # commit=False - the single commit below covers tag, meta, and chat_tag.
+                await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
                 if tag_id not in chat.meta.get('tags', []):
                     chat.meta = {
                         **chat.meta,
-                        # Dedupe preserving order.
                         'tags': list(dict.fromkeys(chat.meta.get('tags', []) + [tag_id])),
                     }
 
@@ -1501,13 +1499,15 @@ class ChatTable:
     ) -> int:
         async with get_async_db_context(db) as db:
             tag_id = tag_name.replace(' ', '_').lower()
-            # Join condition includes user_id so the chat_tag_user_tag_idx
-            # composite index is used; chat.id alone would also be correct
-            # (PK implies user_id) but defeats that index.
             stmt = (
                 select(func.count(Chat.id))
-                .join(ChatTag, and_(ChatTag.chat_id == Chat.id, ChatTag.user_id == Chat.user_id))
-                .where(Chat.user_id == user_id, Chat.archived.is_(False), ChatTag.tag_id == tag_id)
+                .join(ChatTag, ChatTag.chat_id == Chat.id)
+                .where(
+                    Chat.user_id == user_id,
+                    ChatTag.user_id == user_id,
+                    ChatTag.tag_id == tag_id,
+                    Chat.archived.is_(False),
+                )
             )
             result = await db.execute(stmt)
             return result.scalar()
@@ -1519,23 +1519,36 @@ class ChatTable:
         threshold: int = 0,
         db: Optional[AsyncSession] = None,
     ) -> None:
-        """Delete tag rows from *tag_ids* that appear in at most *threshold*
-        non-archived chats for *user_id*.  One query to find orphans, one to
-        delete them.
+        """Delete tag rows from *tag_ids* whose non-archived chat reference
+        count for *user_id* is at most *threshold*.
 
-        Use threshold=0 after a tag is already removed from a chat's meta.
-        Use threshold=1 when the chat itself is about to be deleted (the
-        referencing chat still exists at query time).
+        threshold=0: call after a tag has already been removed from a chat.
+        threshold=1: call before the referencing chat is deleted.
         """
         if not tag_ids:
             return
         async with get_async_db_context(db) as db:
-            orphans = []
-            for tag_id in tag_ids:
-                count = await self.count_chats_by_tag_name_and_user_id(tag_id, user_id, db=db)
-                if count <= threshold:
-                    orphans.append(tag_id)
-            await Tags.delete_tags_by_ids_and_user_id(orphans, user_id, db=db)
+            # One aggregate query replaces the former per-tag-id COUNT loop.
+            reference_counts_stmt = (
+                select(ChatTag.tag_id, func.count(Chat.id))
+                .join(Chat, Chat.id == ChatTag.chat_id)
+                .where(
+                    ChatTag.user_id == user_id,
+                    Chat.user_id == user_id,
+                    Chat.archived.is_(False),
+                    ChatTag.tag_id.in_(tag_ids),
+                )
+                .group_by(ChatTag.tag_id)
+            )
+            reference_count_by_tag_id = dict(
+                (row[0], row[1]) for row in (await db.execute(reference_counts_stmt)).all()
+            )
+            orphan_tag_ids = [
+                tag_id
+                for tag_id in tag_ids
+                if reference_count_by_tag_id.get(tag_id, 0) <= threshold
+            ]
+            await Tags.delete_tags_by_ids_and_user_id(orphan_tag_ids, user_id, db=db)
 
     async def count_chats_by_folder_id_and_user_id(
         self, folder_id: str, user_id: str, db: Optional[AsyncSession] = None
@@ -1584,13 +1597,10 @@ class ChatTable:
         except Exception:
             return False
 
+    # NOTE: ChatMessage / ChatTag are deleted explicitly - SQLite only
+    # enforces FK cascades when `PRAGMA foreign_keys = ON` is set, which
+    # isn't guaranteed at runtime. Keep sibling delete_* methods in sync.
     async def delete_chat_by_id(self, id: str, db: Optional[AsyncSession] = None) -> bool:
-        # NOTE: ChatMessage / ChatTag rows are deleted explicitly rather than
-        # relying on the FK ON DELETE CASCADE because SQLite only enforces
-        # foreign-key cascades when `PRAGMA foreign_keys = ON` is set, which
-        # the open-webui runtime doesn't universally guarantee. The same
-        # defensive pattern is used for ChatMessage in the sibling methods
-        # below - keep these in sync.
         try:
             async with get_async_db_context(db) as db:
                 await db.execute(update(AutomationRun).filter_by(chat_id=id).values(chat_id=None))
@@ -1682,11 +1692,11 @@ class ChatTable:
                 shared_chat_ids = [f'shared-{row[0]}' for row in id_rows]
 
                 if shared_chat_ids:
-                    # Get shared chat IDs to delete associated messages
                     shared_result = await db.execute(select(Chat.id).filter(Chat.user_id.in_(shared_chat_ids)))
                     shared_ids = [row[0] for row in shared_result.all()]
                     if shared_ids:
                         await db.execute(delete(ChatMessage).filter(ChatMessage.chat_id.in_(shared_ids)))
+                        await db.execute(delete(ChatTag).filter(ChatTag.chat_id.in_(shared_ids)))
                     await db.execute(delete(Chat).filter(Chat.user_id.in_(shared_chat_ids)))
                     await db.commit()
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -72,8 +72,10 @@ class Chat(Base):
     )
 
 
-# user_id in the PK is redundant with chat_id but enables the composite FK
-# to tag(id, user_id) and user-scoped queries without joining chat.
+# Invariant (enforced by writers, not by the schema): chat_tag.user_id equals
+# chat(chat_id).user_id. user_id is kept in the PK so the composite FK to
+# tag(id, user_id) is declarable - SQL can't reference just part of a
+# composite PK on the parent side.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -395,7 +397,8 @@ class ChatTable:
             for form_data in chat_import_forms:
                 chat_model = self._chat_import_form_to_chat_model(user_id, form_data)
 
-                # Tags now live in chat_tag, not meta.
+                # Tags now live in chat_tag, not meta. Entries are validated
+                # per-item below; the list may contain non-strings from legacy data.
                 raw_tag_names: list = []
                 if isinstance(chat_model.meta, dict) and 'tags' in chat_model.meta:
                     candidate = chat_model.meta.get('tags')
@@ -1271,7 +1274,7 @@ class ChatTable:
             if 'none' in tag_ids:
                 chat_has_any_tag = select(ChatTag.chat_id).where(ChatTag.chat_id == Chat.id)
                 stmt = stmt.filter(~exists(chat_has_any_tag))
-            else:
+            elif tag_ids:
                 for required_tag_id in tag_ids:
                     chat_has_this_tag = select(ChatTag.chat_id).where(
                         ChatTag.chat_id == Chat.id,

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -440,8 +440,7 @@ class ChatTable:
                 await Tags.ensure_tags_exist(
                     list(display_name_by_tag_id.values()), user_id, db=db, commit=False
                 )
-                # Flush so the tag rows hit the DB before chat_tag's composite
-                # FK is checked on the chat_tag flush at commit-time.
+                # Flush so tag rows land before chat_tag's composite FK check.
                 await db.flush()
             if new_chat_tag_rows:
                 db.add_all(new_chat_tag_rows)
@@ -746,10 +745,8 @@ class ChatTable:
             return None
 
     async def delete_shared_chat_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> bool:
-        # ChatMessage / ChatTag deleted explicitly - see delete_chat_by_id
-        # NOTE re: SQLite PRAGMA foreign_keys. The ChatTag delete is
-        # defensive: shared snapshots shouldn't have chat_tag rows, but
-        # clean up if any leaked in.
+        # See delete_chat_by_id NOTE (SQLite PRAGMA). ChatTag delete is
+        # defensive - shared snapshots shouldn't have chat_tag rows.
         try:
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Chat.id).filter_by(user_id=f'shared-{chat_id}'))

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -8,7 +8,13 @@ from sqlalchemy import select, delete, update, func, or_, and_, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
-from open_webui.internal.db import Base, JSONField, get_async_db_context, insert_on_conflict_nothing
+from open_webui.internal.db import (
+    Base,
+    JSONField,
+    get_async_db_context,
+    insert_all_on_conflict_nothing,
+    insert_on_conflict_nothing,
+)
 from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
@@ -413,7 +419,10 @@ class ChatTable:
                     if not isinstance(raw_tag_name, str):
                         continue
                     tag_id = normalize_tag_id(raw_tag_name)
-                    if not tag_id or tag_id in seen_tag_ids_in_chat:
+                    # 'none' is the sentinel used by the search "tag:none"
+                    # filter to mean "no tags" - skip it so it never becomes
+                    # a real association.
+                    if not tag_id or tag_id == 'none' or tag_id in seen_tag_ids_in_chat:
                         continue
                     seen_tag_ids_in_chat.add(tag_id)
                     display_name_by_tag_id.setdefault(tag_id, raw_tag_name)
@@ -530,15 +539,17 @@ class ChatTable:
                     db=db,
                     commit=False,
                 )
-                # ON CONFLICT DO NOTHING per row so concurrent adds of the
-                # same (chat, tag, user) don't raise IntegrityError.
-                for tag_id in to_add:
-                    await insert_on_conflict_nothing(
-                        db,
-                        ChatTag,
-                        {'chat_id': id, 'tag_id': tag_id, 'user_id': user.id},
-                        index_elements=['chat_id', 'tag_id', 'user_id'],
-                    )
+                # Bulk ON CONFLICT DO NOTHING so concurrent adds of the same
+                # (chat, tag, user) don't raise IntegrityError.
+                await insert_all_on_conflict_nothing(
+                    db,
+                    ChatTag,
+                    [
+                        {'chat_id': id, 'tag_id': tag_id, 'user_id': user.id}
+                        for tag_id in to_add
+                    ],
+                    index_elements=['chat_id', 'tag_id', 'user_id'],
+                )
             if to_remove:
                 await db.execute(
                     delete(ChatTag).where(
@@ -553,10 +564,7 @@ class ChatTable:
             if to_remove:
                 await self.delete_orphan_tags_for_user(list(to_remove), user.id, db=db)
 
-            # Response-only meta overlay for back-compat with ChatModel.meta.tags readers.
-            response = ChatModel.model_validate(chat)
-            response.meta = {**(response.meta or {}), 'tags': new_tag_ids}
-            return response
+            return ChatModel.model_validate(chat)
 
     async def get_chat_title_by_id(self, id: str) -> Optional[str]:
         async with get_async_db_context() as db:
@@ -1392,7 +1400,8 @@ class ChatTable:
         except Exception:
             return None
 
-    # Returns [] for a missing/foreign chat.
+    # Returns the tag_ids associated with (id, user_id) in chat_tag. Empty
+    # list if the chat doesn't exist OR the user has no chat_tag rows for it.
     async def get_chat_tag_ids_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[str]:
@@ -1475,12 +1484,6 @@ class ChatTable:
                 if chat is None or chat.user_id != user_id:
                     return None
 
-                # Read the existing set before writing so we can build the
-                # response tag list in memory (avoids a post-commit round-trip).
-                existing_tag_ids = await self.get_chat_tag_ids_by_id_and_user_id(
-                    id, user_id, db=db
-                )
-
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
                 # ON CONFLICT DO NOTHING avoids a TOCTOU race on concurrent adds.
@@ -1492,13 +1495,9 @@ class ChatTable:
                 )
 
                 await db.commit()
-
-                response = ChatModel.model_validate(chat)
-                merged_tag_ids = list(dict.fromkeys([*existing_tag_ids, tag_id]))
-                response.meta = {**(response.meta or {}), 'tags': merged_tag_ids}
-                return response
-        except Exception as e:
-            log.exception(f'add_chat_tag failed for chat={id} tag={tag_name}: {e}')
+                return ChatModel.model_validate(chat)
+        except Exception:
+            log.exception('add_chat_tag failed for chat=%s tag=%s', id, tag_name)
             return None
 
     async def count_chats_by_tag_name_and_user_id(
@@ -1582,8 +1581,8 @@ class ChatTable:
                 )
                 await db.commit()
                 return True
-        except Exception as e:
-            log.exception(f'delete_tag failed for chat={id} tag={tag_name}: {e}')
+        except Exception:
+            log.exception('delete_tag failed for chat=%s tag=%s', id, tag_name)
             return False
 
     async def delete_all_tags_by_id_and_user_id(self, id: str, user_id: str, db: Optional[AsyncSession] = None) -> bool:
@@ -1592,8 +1591,8 @@ class ChatTable:
                 await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user_id))
                 await db.commit()
                 return True
-        except Exception as e:
-            log.exception(f'delete_all_tags failed for chat={id}: {e}')
+        except Exception:
+            log.exception('delete_all_tags failed for chat=%s', id)
             return False
 
     # NOTE: ChatMessage / ChatTag are deleted explicitly - SQLite only

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -72,6 +72,13 @@ class Chat(Base):
     )
 
 
+# Normalized chat/tag association. Introduced to replace the denormalized
+# chat.meta['tags'] JSON array; meta['tags'] is still dual-written for
+# rollback safety and should be removed in a follow-up migration once all
+# deployments are past revision 17a6d37e23d2. When that happens, remove the
+# meta['tags'] writes in the methods below and switch any remaining readers
+# (e.g. the tag filters in get_chats_by_user_id_and_search_text) to join
+# ChatTag instead of scanning JSON.
 class ChatTag(Base):
     __tablename__ = 'chat_tag'
 
@@ -81,9 +88,17 @@ class ChatTag(Base):
 
     __table_args__ = (
         PrimaryKeyConstraint('chat_id', 'tag_id', 'user_id', name='pk_chat_tag'),
-        ForeignKeyConstraint(['chat_id'], ['chat.id'], name='fk_chat_tag_chat_id', ondelete='CASCADE'),
         ForeignKeyConstraint(
-            ['tag_id', 'user_id'], ['tag.id', 'tag.user_id'], name='fk_chat_tag_tag', ondelete='CASCADE'
+            ['chat_id'],
+            ['chat.id'],
+            name='fk_chat_tag_chat_id',
+            ondelete='CASCADE',
+        ),
+        ForeignKeyConstraint(
+            ['tag_id', 'user_id'],
+            ['tag.id', 'tag.user_id'],
+            name='fk_chat_tag_tag',
+            ondelete='CASCADE',
         ),
         Index('chat_tag_user_tag_idx', 'user_id', 'tag_id'),
         Index('chat_tag_chat_idx', 'chat_id'),
@@ -401,6 +416,37 @@ class ChatTable:
             except Exception as e:
                 log.warning(f'Failed to write imported messages to chat_message table: {e}')
 
+            # Dual-write tags from chat.meta['tags'] to chat_tag. Without this,
+            # imported/cloned chats would have meta['tags'] set but no chat_tag
+            # rows, so they wouldn't appear in tag-filtered lists.
+            try:
+                tag_assocs: list[ChatTag] = []
+                raw_names_by_user: dict[str, list[str]] = {}
+                for chat_obj in chats:
+                    meta = chat_obj.meta or {}
+                    raw_tags = meta.get('tags') if isinstance(meta, dict) else None
+                    if not isinstance(raw_tags, list):
+                        continue
+                    seen: set = set()
+                    for raw in raw_tags:
+                        if not isinstance(raw, str):
+                            continue
+                        tid = raw.replace(' ', '_').lower()
+                        if not tid or tid in seen:
+                            continue
+                        seen.add(tid)
+                        raw_names_by_user.setdefault(user_id, []).append(raw)
+                        tag_assocs.append(
+                            ChatTag(chat_id=chat_obj.id, tag_id=tid, user_id=user_id)
+                        )
+                for uid, names in raw_names_by_user.items():
+                    await Tags.ensure_tags_exist(names, uid, db=db)
+                if tag_assocs:
+                    db.add_all(tag_assocs)
+                    await db.commit()
+            except Exception as e:
+                log.warning(f'Failed to write imported chat tags to chat_tag table: {e}')
+
             return [ChatModel.model_validate(chat) for chat in chats]
 
     async def update_chat_by_id(self, id: str, chat: dict, db: Optional[AsyncSession] = None) -> Optional[ChatModel]:
@@ -455,21 +501,23 @@ class ChatTable:
 
             old_tags = chat.meta.get('tags', [])
             new_tags = [t for t in tags if t.replace(' ', '_').lower() != 'none']
+            # Dedupe preserving order.
             new_tag_ids = list(dict.fromkeys(t.replace(' ', '_').lower() for t in new_tags))
 
+            # Write chat.meta and chat_tag rows atomically: a crash between the
+            # meta update and the association rewrite would otherwise leave the
+            # two stores disagreeing, and since chat_tag is now the source of
+            # truth for list/count queries, that's a user-visible bug.
             chat.meta = {**chat.meta, 'tags': new_tag_ids}
-            await db.commit()
-            await db.refresh(chat)
-
             await Tags.ensure_tags_exist(new_tags, user.id, db=db)
-
-            # Rewrite the normalized chat_tag association rows for this chat.
             await db.execute(delete(ChatTag).filter_by(chat_id=id, user_id=user.id))
             if new_tag_ids:
                 db.add_all(
                     [ChatTag(chat_id=id, tag_id=tag_id, user_id=user.id) for tag_id in new_tag_ids]
                 )
+
             await db.commit()
+            await db.refresh(chat)
 
             removed = set(old_tags) - set(new_tag_ids)
             if removed:
@@ -1350,13 +1398,6 @@ class ChatTable:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user_id))
             tag_ids = [row[0] for row in result.all()]
-            if not tag_ids:
-                # Transitional fallback for chats whose normalized chat_tag rows
-                # haven't been populated yet (e.g. before the backfill migration
-                # ran for this chat's row, or data written by old code paths).
-                chat = await db.get(Chat, id)
-                if chat is not None:
-                    tag_ids = chat.meta.get('tags', []) or []
             return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
 
     async def get_chat_list_by_user_id_and_tag_name(
@@ -1401,20 +1442,26 @@ class ChatTable:
         self, id: str, user_id: str, tag_name: str, db: Optional[AsyncSession] = None
     ) -> Optional[ChatModel]:
         tag_id = tag_name.replace(' ', '_').lower()
-        await Tags.ensure_tags_exist([tag_name], user_id, db=db)
         try:
             async with get_async_db_context(db) as db:
+                # Inside the same session so a failure below also rolls back
+                # any newly-created tag row.
+                await Tags.ensure_tags_exist([tag_name], user_id, db=db)
+
                 chat = await db.get(Chat, id)
                 if tag_id not in chat.meta.get('tags', []):
                     chat.meta = {
                         **chat.meta,
-                        'tags': list(set(chat.meta.get('tags', []) + [tag_id])),
+                        # Dedupe preserving order.
+                        'tags': list(dict.fromkeys(chat.meta.get('tags', []) + [tag_id])),
                     }
 
-                existing = await db.execute(
-                    select(ChatTag).filter_by(chat_id=id, tag_id=tag_id, user_id=user_id)
+                has_assoc = await db.execute(
+                    select(ChatTag.chat_id).filter_by(
+                        chat_id=id, tag_id=tag_id, user_id=user_id
+                    )
                 )
-                if existing.scalar_one_or_none() is None:
+                if has_assoc.first() is None:
                     db.add(ChatTag(chat_id=id, tag_id=tag_id, user_id=user_id))
 
                 await db.commit()
@@ -1428,10 +1475,13 @@ class ChatTable:
     ) -> int:
         async with get_async_db_context(db) as db:
             tag_id = tag_name.replace(' ', '_').lower()
+            # Join condition includes user_id so the chat_tag_user_tag_idx
+            # composite index is used; chat.id alone would also be correct
+            # (PK implies user_id) but defeats that index.
             stmt = (
                 select(func.count(Chat.id))
                 .join(ChatTag, and_(ChatTag.chat_id == Chat.id, ChatTag.user_id == Chat.user_id))
-                .where(Chat.user_id == user_id, Chat.archived == False, ChatTag.tag_id == tag_id)  # noqa: E712
+                .where(Chat.user_id == user_id, Chat.archived.is_(False), ChatTag.tag_id == tag_id)
             )
             result = await db.execute(stmt)
             return result.scalar() or 0
@@ -1509,6 +1559,12 @@ class ChatTable:
             return False
 
     async def delete_chat_by_id(self, id: str, db: Optional[AsyncSession] = None) -> bool:
+        # NOTE: ChatMessage / ChatTag rows are deleted explicitly rather than
+        # relying on the FK ON DELETE CASCADE because SQLite only enforces
+        # foreign-key cascades when `PRAGMA foreign_keys = ON` is set, which
+        # the open-webui runtime doesn't universally guarantee. The same
+        # defensive pattern is used for ChatMessage in the sibling methods
+        # below - keep these in sync.
         try:
             async with get_async_db_context(db) as db:
                 await db.execute(update(AutomationRun).filter_by(chat_id=id).values(chat_id=None))

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -8,7 +8,7 @@ from sqlalchemy import select, delete, update, func, or_, and_, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import bindparam
-from open_webui.internal.db import Base, JSONField, get_async_db_context, insert_ignore_conflict
+from open_webui.internal.db import Base, JSONField, get_async_db_context, insert_on_conflict_nothing
 from open_webui.models.tags import TagModel, Tag, Tags, normalize_tag_id
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
@@ -529,7 +529,12 @@ class ChatTable:
             if removed_tag_ids:
                 await self.delete_orphan_tags_for_user(list(removed_tag_ids), user.id, db=db)
 
-            return ChatModel.model_validate(chat)
+            # Overlay the new tag ids on the response only - chat.meta is
+            # no longer the source of truth, but existing clients may still
+            # read ChatModel.meta['tags'].
+            response = ChatModel.model_validate(chat)
+            response.meta = {**(response.meta or {}), 'tags': new_tag_ids}
+            return response
 
     async def get_chat_title_by_id(self, id: str) -> Optional[str]:
         async with get_async_db_context() as db:
@@ -1271,13 +1276,20 @@ class ChatTable:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
 
             # 'tag:none' = no associations; 'tag:X tag:Y' = has both.
+            # The ChatTag.user_id predicate is redundant with the writer-enforced
+            # invariant, but keeping it defends against any future drift and
+            # drives the chat_tag_user_tag_idx lookup.
             if 'none' in tag_ids:
-                chat_has_any_tag = select(ChatTag.chat_id).where(ChatTag.chat_id == Chat.id)
+                chat_has_any_tag = select(ChatTag.chat_id).where(
+                    ChatTag.chat_id == Chat.id,
+                    ChatTag.user_id == user_id,
+                )
                 stmt = stmt.filter(~exists(chat_has_any_tag))
             elif tag_ids:
                 for required_tag_id in tag_ids:
                     chat_has_this_tag = select(ChatTag.chat_id).where(
                         ChatTag.chat_id == Chat.id,
+                        ChatTag.user_id == user_id,
                         ChatTag.tag_id == required_tag_id,
                     )
                     stmt = stmt.filter(exists(chat_has_this_tag))
@@ -1360,12 +1372,35 @@ class ChatTable:
         except Exception:
             return None
 
+    # Returns [] for a missing/foreign chat.
     async def get_chat_tag_ids_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[str]:
         async with get_async_db_context(db) as db:
             rows = await db.execute(select(ChatTag.tag_id).filter_by(chat_id=id, user_id=user_id))
             return [row[0] for row in rows.all()]
+
+    async def get_chat_tag_ids_by_chat_ids_and_user_id(
+        self, chat_ids: list[str], user_id: str, db: Optional[AsyncSession] = None
+    ) -> dict[str, list[str]]:
+        """Batch equivalent of get_chat_tag_ids_by_id_and_user_id.
+
+        Every chat_id from *chat_ids* is present in the result (empty list if
+        no tags), so callers can look up without a .get() default.
+        """
+        tag_ids_by_chat_id: dict[str, list[str]] = {chat_id: [] for chat_id in chat_ids}
+        if not chat_ids:
+            return tag_ids_by_chat_id
+        async with get_async_db_context(db) as db:
+            rows = await db.execute(
+                select(ChatTag.chat_id, ChatTag.tag_id).where(
+                    ChatTag.chat_id.in_(chat_ids),
+                    ChatTag.user_id == user_id,
+                )
+            )
+            for chat_id, tag_id in rows.all():
+                tag_ids_by_chat_id[chat_id].append(tag_id)
+        return tag_ids_by_chat_id
 
     async def get_chat_tags_by_id_and_user_id(
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
@@ -1423,15 +1458,21 @@ class ChatTable:
                 await Tags.ensure_tags_exist([tag_name], user_id, db=db, commit=False)
 
                 # ON CONFLICT DO NOTHING avoids a TOCTOU race on concurrent adds.
-                await insert_ignore_conflict(
+                await insert_on_conflict_nothing(
                     db,
                     ChatTag,
                     {'chat_id': id, 'tag_id': tag_id, 'user_id': user_id},
-                    conflict_cols=['chat_id', 'tag_id', 'user_id'],
+                    index_elements=['chat_id', 'tag_id', 'user_id'],
                 )
 
                 await db.commit()
-                return ChatModel.model_validate(chat)
+
+                response = ChatModel.model_validate(chat)
+                response.meta = {
+                    **(response.meta or {}),
+                    'tags': await self.get_chat_tag_ids_by_id_and_user_id(id, user_id, db=db),
+                }
+                return response
         except Exception:
             return None
 

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -19,6 +19,12 @@ log = logging.getLogger(__name__)
 # To name a thing is to claim it. The creator has
 # already named everything stored in this table.
 ####################
+# Reserved tag_id used as a sentinel by the tag:none search filter
+# ("chat has no tags"). Writers must reject it so it can never become a
+# real association.
+RESERVED_TAG_ID_NONE = 'none'
+
+
 def normalize_tag_id(raw: str) -> str:
     """Canonical tag_id form. This is the PK for tag and chat_tag, so every
     call site that derives an id from a user-supplied name must use this."""
@@ -138,6 +144,8 @@ class TagTable:
         must remain atomic (e.g. a dual-write that also touches chat_tag);
         the caller is then responsible for committing the session.
         """
+        if not commit and db is None:
+            raise ValueError('ensure_tags_exist(commit=False) requires an explicit db session')
         if not names:
             return
         # Dedupe on normalized id, first display name wins. ON CONFLICT DO

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -37,9 +37,6 @@ class Tag(Base):
         Index('user_id_idx', 'user_id'),
     )
 
-    # Unique constraint ensuring (id, user_id) is unique, not just the `id` column
-    __table_args__ = (PrimaryKeyConstraint('id', 'user_id', name='pk_id_user_id'),)
-
 
 class TagModel(BaseModel):
     id: str

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -19,6 +19,12 @@ log = logging.getLogger(__name__)
 # To name a thing is to claim it. The creator has
 # already named everything stored in this table.
 ####################
+def normalize_tag_id(raw: str) -> str:
+    """Canonical tag_id form. This is the PK for tag and chat_tag, so every
+    call site that derives an id from a user-supplied name must use this."""
+    return raw.replace(' ', '_').lower()
+
+
 class Tag(Base):
     __tablename__ = 'tag'
     id = Column(String)
@@ -56,7 +62,7 @@ class TagChatIdForm(BaseModel):
 class TagTable:
     async def insert_new_tag(self, name: str, user_id: str, db: Optional[AsyncSession] = None) -> Optional[TagModel]:
         async with get_async_db_context(db) as db:
-            id = name.replace(' ', '_').lower()
+            id = normalize_tag_id(name)
             tag = TagModel(**{'id': id, 'user_id': user_id, 'name': name})
             try:
                 result = Tag(**tag.model_dump())
@@ -75,7 +81,7 @@ class TagTable:
         self, name: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> Optional[TagModel]:
         try:
-            id = name.replace(' ', '_').lower()
+            id = normalize_tag_id(name)
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Tag).filter_by(id=id, user_id=user_id))
                 tag = result.scalars().first()
@@ -98,7 +104,7 @@ class TagTable:
     async def delete_tag_by_name_and_user_id(self, name: str, user_id: str, db: Optional[AsyncSession] = None) -> bool:
         try:
             async with get_async_db_context(db) as db:
-                id = name.replace(' ', '_').lower()
+                id = normalize_tag_id(name)
                 result = await db.execute(delete(Tag).filter_by(id=id, user_id=user_id))
                 log.debug(f'res: {result.rowcount}')
                 await db.commit()
@@ -137,18 +143,18 @@ class TagTable:
         """
         if not names:
             return
-        ids = [n.replace(' ', '_').lower() for n in names]
+        ids = [normalize_tag_id(n) for n in names]
         async with get_async_db_context(db) as db:
             result = await db.execute(select(Tag.id).filter(Tag.id.in_(ids), Tag.user_id == user_id))
             existing = {row[0] for row in result.all()}
             # Dedupe on normalized id so callers passing ['My Tag', 'my tag']
             # don't stage two Tag rows with the same composite PK.
-            seen: set = set()
-            new_tags = []
+            seen_tag_ids: set[str] = set()
+            new_tags: list[Tag] = []
             for tag_id, name in zip(ids, names):
-                if tag_id in existing or tag_id in seen:
+                if tag_id in existing or tag_id in seen_tag_ids:
                     continue
-                seen.add(tag_id)
+                seen_tag_ids.add(tag_id)
                 new_tags.append(Tag(id=tag_id, name=name, user_id=user_id))
             if new_tags:
                 db.add_all(new_tags)

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -147,8 +147,8 @@ class TagTable:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(Tag.id).filter(Tag.id.in_(ids), Tag.user_id == user_id))
             existing = {row[0] for row in result.all()}
-            # Dedupe on normalized id so callers passing ['My Tag', 'my tag']
-            # don't stage two Tag rows with the same composite PK.
+            # Dedupe on normalized id - ['My Tag', 'my tag'] would otherwise
+            # stage two Tag rows with the same composite PK.
             seen_tag_ids: set[str] = set()
             new_tags: list[Tag] = []
             for tag_id, name in zip(ids, names):

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -122,20 +122,38 @@ class TagTable:
             log.error(f'delete_tags_by_ids: {e}')
             return False
 
-    async def ensure_tags_exist(self, names: list[str], user_id: str, db: Optional[AsyncSession] = None) -> None:
-        """Create tag rows for any *names* that don't already exist for *user_id*."""
+    async def ensure_tags_exist(
+        self,
+        names: list[str],
+        user_id: str,
+        db: Optional[AsyncSession] = None,
+        commit: bool = True,
+    ) -> None:
+        """Create tag rows for any *names* that don't already exist for *user_id*.
+
+        Pass ``commit=False`` when the caller owns a larger transaction that
+        must remain atomic (e.g. a dual-write that also touches chat_tag);
+        the caller is then responsible for committing the session.
+        """
         if not names:
             return
         ids = [n.replace(' ', '_').lower() for n in names]
         async with get_async_db_context(db) as db:
             result = await db.execute(select(Tag.id).filter(Tag.id.in_(ids), Tag.user_id == user_id))
             existing = {row[0] for row in result.all()}
-            new_tags = [
-                Tag(id=tag_id, name=name, user_id=user_id) for tag_id, name in zip(ids, names) if tag_id not in existing
-            ]
+            # Dedupe on normalized id so callers passing ['My Tag', 'my tag']
+            # don't stage two Tag rows with the same composite PK.
+            seen: set = set()
+            new_tags = []
+            for tag_id, name in zip(ids, names):
+                if tag_id in existing or tag_id in seen:
+                    continue
+                seen.add(tag_id)
+                new_tags.append(Tag(id=tag_id, name=name, user_id=user_id))
             if new_tags:
                 db.add_all(new_tags)
-                await db.commit()
+                if commit:
+                    await db.commit()
 
 
 Tags = TagTable()

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, get_async_db_context, insert_all_on_conflict_nothing
 
 
 from pydantic import BaseModel, ConfigDict
@@ -140,23 +140,21 @@ class TagTable:
         """
         if not names:
             return
-        ids = [normalize_tag_id(n) for n in names]
+        # Dedupe on normalized id, first display name wins. ON CONFLICT DO
+        # NOTHING handles the concurrent-insert race so we don't need the
+        # old SELECT-then-add check.
+        values_by_tag_id: dict[str, dict] = {}
+        for name in names:
+            tag_id = normalize_tag_id(name)
+            values_by_tag_id.setdefault(
+                tag_id, {'id': tag_id, 'name': name, 'user_id': user_id}
+            )
         async with get_async_db_context(db) as db:
-            result = await db.execute(select(Tag.id).filter(Tag.id.in_(ids), Tag.user_id == user_id))
-            existing = {row[0] for row in result.all()}
-            # Dedupe on normalized id - ['My Tag', 'my tag'] would otherwise
-            # stage two Tag rows with the same composite PK.
-            seen_tag_ids: set[str] = set()
-            new_tags: list[Tag] = []
-            for tag_id, name in zip(ids, names):
-                if tag_id in existing or tag_id in seen_tag_ids:
-                    continue
-                seen_tag_ids.add(tag_id)
-                new_tags.append(Tag(id=tag_id, name=name, user_id=user_id))
-            if new_tags:
-                db.add_all(new_tags)
-                if commit:
-                    await db.commit()
+            await insert_all_on_conflict_nothing(
+                db, Tag, list(values_by_tag_id.values()), index_elements=['id', 'user_id']
+            )
+            if commit:
+                await db.commit()
 
 
 Tags = TagTable()

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -429,7 +429,6 @@ async def get_model_overview(
             )
             current += timedelta(days=1)
 
-    # One aggregate query replaces the former per-chat_id N+1 meta scan.
     tag_count_query = (
         select(ChatTag.tag_id, func.count())
         .where(ChatTag.chat_id.in_(chat_ids))

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -13,7 +13,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.users import Users
 from open_webui.models.feedbacks import Feedbacks
 from open_webui.utils.auth import get_admin_user
-from open_webui.internal.db import get_async_session, SQL_PARAM_BATCH
+from open_webui.internal.db import get_async_session, sql_param_batch
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -431,11 +431,12 @@ async def get_model_overview(
             )
             current += timedelta(days=1)
 
-    # Chunk the IN clause so wide date ranges can't push it past PG's
-    # 65,535 bind-param ceiling, then aggregate in Python.
+    # Chunk the IN clause to respect each dialect's bind-param ceiling,
+    # then aggregate in Python.
     tag_counts: Counter[str] = Counter()
-    for start in range(0, len(chat_ids), SQL_PARAM_BATCH):
-        batch = chat_ids[start:start + SQL_PARAM_BATCH]
+    batch_size = sql_param_batch(db.get_bind().dialect.name)
+    for start in range(0, len(chat_ids), batch_size):
+        batch = chat_ids[start:start + batch_size]
         rows = (await db.execute(
             select(ChatTag.tag_id, func.count())
             .where(ChatTag.chat_id.in_(batch))

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -6,12 +6,13 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from open_webui.models.chat_messages import ChatMessages, ChatMessageModel
-from open_webui.models.chats import Chats
+from open_webui.models.chats import Chats, ChatTag
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
 from open_webui.models.feedbacks import Feedbacks
 from open_webui.utils.auth import get_admin_user
 from open_webui.internal.db import get_async_session
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -428,15 +429,15 @@ async def get_model_overview(
             )
             current += timedelta(days=1)
 
-    # Get chat tags
-    tag_counts: dict[str, int] = defaultdict(int)
-    for chat_id in chat_ids:
-        chat = await Chats.get_chat_by_id(chat_id, db=db)
-        if chat and chat.meta:
-            for tag in chat.meta.get('tags', []):
-                tag_counts[tag] += 1
-
-    # Sort by count and take top 10
-    tags = [TagEntry(tag=tag, count=count) for tag, count in sorted(tag_counts.items(), key=lambda x: -x[1])[:10]]
+    # One aggregate query replaces the former per-chat_id N+1 meta scan.
+    tag_count_query = (
+        select(ChatTag.tag_id, func.count())
+        .where(ChatTag.chat_id.in_(chat_ids))
+        .group_by(ChatTag.tag_id)
+        .order_by(func.count().desc())
+        .limit(10)
+    )
+    tag_count_rows = (await db.execute(tag_count_query)).all() if chat_ids else []
+    tags = [TagEntry(tag=row[0], count=row[1]) for row in tag_count_rows]
 
     return ModelOverviewResponse(history=history, tags=tags)

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -5,13 +5,15 @@ import logging
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
+from collections import Counter
+
 from open_webui.models.chat_messages import ChatMessages, ChatMessageModel
 from open_webui.models.chats import Chats, ChatTag
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
 from open_webui.models.feedbacks import Feedbacks
 from open_webui.utils.auth import get_admin_user
-from open_webui.internal.db import get_async_session
+from open_webui.internal.db import get_async_session, SQL_PARAM_BATCH
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -429,14 +431,18 @@ async def get_model_overview(
             )
             current += timedelta(days=1)
 
-    tag_count_query = (
-        select(ChatTag.tag_id, func.count())
-        .where(ChatTag.chat_id.in_(chat_ids))
-        .group_by(ChatTag.tag_id)
-        .order_by(func.count().desc())
-        .limit(10)
-    )
-    tag_count_rows = (await db.execute(tag_count_query)).all() if chat_ids else []
-    tags = [TagEntry(tag=row[0], count=row[1]) for row in tag_count_rows]
+    # Chunk the IN clause so wide date ranges can't push it past PG's
+    # 65,535 bind-param ceiling, then aggregate in Python.
+    tag_counts: Counter[str] = Counter()
+    for start in range(0, len(chat_ids), SQL_PARAM_BATCH):
+        batch = chat_ids[start:start + SQL_PARAM_BATCH]
+        rows = (await db.execute(
+            select(ChatTag.tag_id, func.count())
+            .where(ChatTag.chat_id.in_(batch))
+            .group_by(ChatTag.tag_id)
+        )).all()
+        for tag_id, count in rows:
+            tag_counts[tag_id] += count
+    tags = [TagEntry(tag=t, count=c) for t, c in tag_counts.most_common(10)]
 
     return ModelOverviewResponse(history=history, tags=tags)

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1348,7 +1348,12 @@ async def add_tag_by_id_and_tag_name(
                 detail=ERROR_MESSAGES.DEFAULT("Tag name cannot be 'None'"),
             )
 
-        await Chats.add_chat_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
+        # None => chat disappeared (or ownership broke) between the check
+        # above and the FOR UPDATE lock; surface as 404 rather than a
+        # misleading empty tag list.
+        result = await Chats.add_chat_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
+        if result is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
         return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1204,9 +1204,7 @@ async def clone_shared_chat_by_id(
 async def archive_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        # chat_tag rows persist across archive toggles; counts and list
-        # queries already filter archived=False so archived chats are
-        # excluded from the tag UI without touching the association table.
+        # chat_tag rows persist; list/count queries already filter archived=False.
         chat = await Chats.toggle_chat_archive_by_id(id, db=db)
         return ChatResponse(**chat.model_dump())
     else:
@@ -1338,7 +1336,6 @@ async def add_tag_by_id_and_tag_name(
                 detail=ERROR_MESSAGES.DEFAULT("Tag name cannot be 'None'"),
             )
 
-        # add_chat_tag uses ON CONFLICT DO NOTHING, so no pre-check needed.
         await Chats.add_chat_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
         return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:
@@ -1380,8 +1377,7 @@ async def delete_all_tags_by_id(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        # Snapshot current tag_ids before clearing so orphan cleanup knows
-        # which tags to re-count.
+        # Snapshot before clearing so orphan cleanup knows which tags to re-count.
         old_tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, user.id, db=db)
         await Chats.delete_all_tags_by_id_and_user_id(id, user.id, db=db)
         await Chats.delete_orphan_tags_for_user(old_tag_ids, user.id, db=db)

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -104,6 +104,10 @@ async def get_session_user_chat_usage_stats(
         chats = result.items
         total = result.total
 
+        tag_ids_by_chat_id = await Chats.get_chat_tag_ids_by_chat_ids_and_user_id(
+            [chat.id for chat in chats], user.id, db=db
+        )
+
         chat_stats = []
         for chat in chats:
             messages_map = chat.chat.get('history', {}).get('messages', {})
@@ -177,7 +181,7 @@ async def get_session_user_chat_usage_stats(
                             'average_response_time': average_response_time,
                             'average_user_message_content_length': average_user_message_content_length,
                             'average_assistant_message_content_length': average_assistant_message_content_length,
-                            'tags': await Chats.get_chat_tag_ids_by_id_and_user_id(chat.id, user.id, db=db),
+                            'tags': tag_ids_by_chat_id[chat.id],
                             'last_message_at': message_list[-1].get('timestamp', None),
                             'updated_at': chat.updated_at,
                             'created_at': chat.created_at,

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -212,7 +212,7 @@ class ChatStatsExportList(BaseModel):
     page: int
 
 
-def _process_chat_for_export(chat) -> Optional[ChatStatsExport]:
+def _process_chat_for_export(chat, tag_ids: list[str]) -> Optional[ChatStatsExport]:
     try:
 
         def get_message_content_length(message):
@@ -328,7 +328,7 @@ def _process_chat_for_export(chat) -> Optional[ChatStatsExport]:
             user_id=chat.user_id,
             created_at=chat.created_at,
             updated_at=chat.updated_at,
-            tags=await Chats.get_chat_tag_ids_by_id_and_user_id(chat.id, chat.user_id, db=db),
+            tags=tag_ids,
             stats=stats,
             chat=chat_body,
         )
@@ -348,9 +348,12 @@ async def calculate_chat_stats(user_id, skip=0, limit=10, filter=None):
         filter=filter,
     )
 
+    tag_ids_by_chat_id = await Chats.get_chat_tag_ids_by_chat_ids_and_user_id(
+        [c.id for c in result.items], user_id
+    )
     chat_stats_export_list = []
     for chat in result.items:
-        chat_stat = _process_chat_for_export(chat)
+        chat_stat = _process_chat_for_export(chat, tag_ids_by_chat_id.get(chat.id, []))
         if chat_stat:
             chat_stats_export_list.append(chat_stat)
 
@@ -383,9 +386,12 @@ async def generate_chat_stats_jsonl_generator(user_id, filter):
         if not result.items:
             break
 
+        tag_ids_by_chat_id = await Chats.get_chat_tag_ids_by_chat_ids_and_user_id(
+            [c.id for c in result.items], user_id
+        )
         for chat in result.items:
             try:
-                chat_stat = _process_chat_for_export(chat)
+                chat_stat = _process_chat_for_export(chat, tag_ids_by_chat_id.get(chat.id, []))
                 if chat_stat:
                     yield chat_stat.model_dump_json() + '\n'
             except Exception as e:
@@ -474,8 +480,9 @@ async def export_single_chat_stats(
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
             )
 
+        tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(chat.id, chat.user_id, db=db)
         # Process the chat for export (pure computation, no DB)
-        chat_stats = _process_chat_for_export(chat)
+        chat_stats = _process_chat_for_export(chat, tag_ids)
 
         if not chat_stats:
             raise HTTPException(

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -24,7 +24,7 @@ from open_webui.models.chats import (
     ChatHistoryStats,
     MessageStats,
 )
-from open_webui.models.tags import TagModel, Tags, normalize_tag_id
+from open_webui.models.tags import TagModel, Tags, normalize_tag_id, RESERVED_TAG_ID_NONE
 from open_webui.models.folders import Folders
 from open_webui.internal.db import get_async_session
 
@@ -1342,7 +1342,7 @@ async def add_tag_by_id_and_tag_name(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        if normalize_tag_id(form_data.name) == 'none':
+        if normalize_tag_id(form_data.name) == RESERVED_TAG_ID_NONE:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT("Tag name cannot be 'None'"),

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1041,8 +1041,9 @@ async def delete_chat_by_id(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ERROR_MESSAGES.NOT_FOUND,
             )
-        tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, user.id, db=db)
-        await Chats.delete_orphan_tags_for_user(tag_ids, user.id, threshold=1, db=db)
+        # Orphan cleanup is scoped to the chat's owner, not the admin.
+        tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, chat.user_id, db=db)
+        await Chats.delete_orphan_tags_for_user(tag_ids, chat.user_id, threshold=1, db=db)
 
         result = await Chats.delete_chat_by_id(id, db=db)
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -24,7 +24,7 @@ from open_webui.models.chats import (
     ChatHistoryStats,
     MessageStats,
 )
-from open_webui.models.tags import TagModel, Tags
+from open_webui.models.tags import TagModel, Tags, normalize_tag_id
 from open_webui.models.folders import Folders
 from open_webui.internal.db import get_async_session
 
@@ -177,7 +177,7 @@ async def get_session_user_chat_usage_stats(
                             'average_response_time': average_response_time,
                             'average_user_message_content_length': average_user_message_content_length,
                             'average_assistant_message_content_length': average_assistant_message_content_length,
-                            'tags': chat.meta.get('tags', []),
+                            'tags': await Chats.get_chat_tag_ids_by_id_and_user_id(chat.id, user.id, db=db),
                             'last_message_at': message_list[-1].get('timestamp', None),
                             'updated_at': chat.updated_at,
                             'created_at': chat.created_at,
@@ -324,7 +324,7 @@ def _process_chat_for_export(chat) -> Optional[ChatStatsExport]:
             user_id=chat.user_id,
             created_at=chat.created_at,
             updated_at=chat.updated_at,
-            tags=chat.meta.get('tags', []),
+            tags=await Chats.get_chat_tag_ids_by_id_and_user_id(chat.id, chat.user_id, db=db),
             stats=stats,
             chat=chat_body,
         )
@@ -1037,7 +1037,8 @@ async def delete_chat_by_id(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ERROR_MESSAGES.NOT_FOUND,
             )
-        await Chats.delete_orphan_tags_for_user(chat.meta.get('tags', []), user.id, threshold=1, db=db)
+        tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, user.id, db=db)
+        await Chats.delete_orphan_tags_for_user(tag_ids, user.id, threshold=1, db=db)
 
         result = await Chats.delete_chat_by_id(id, db=db)
 
@@ -1055,7 +1056,8 @@ async def delete_chat_by_id(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ERROR_MESSAGES.NOT_FOUND,
             )
-        await Chats.delete_orphan_tags_for_user(chat.meta.get('tags', []), user.id, threshold=1, db=db)
+        tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, user.id, db=db)
+        await Chats.delete_orphan_tags_for_user(tag_ids, user.id, threshold=1, db=db)
 
         result = await Chats.delete_chat_by_id_and_user_id(id, user.id, db=db)
         return result
@@ -1202,16 +1204,10 @@ async def clone_shared_chat_by_id(
 async def archive_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
+        # chat_tag rows persist across archive toggles; counts and list
+        # queries already filter archived=False so archived chats are
+        # excluded from the tag UI without touching the association table.
         chat = await Chats.toggle_chat_archive_by_id(id, db=db)
-
-        tag_ids = chat.meta.get('tags', [])
-        if chat.archived:
-            # Archived chats are excluded from count — clean up orphans
-            await Chats.delete_orphan_tags_for_user(tag_ids, user.id, db=db)
-        else:
-            # Unarchived — ensure tag rows exist
-            await Tags.ensure_tags_exist(tag_ids, user.id, db=db)
-
         return ChatResponse(**chat.model_dump())
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())
@@ -1317,8 +1313,7 @@ async def update_chat_folder_id_by_id(
 async def get_chat_tags_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        tags = chat.meta.get('tags', [])
-        return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
+        return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
@@ -1337,21 +1332,15 @@ async def add_tag_by_id_and_tag_name(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        tags = chat.meta.get('tags', [])
-        tag_id = form_data.name.replace(' ', '_').lower()
-
-        if tag_id == 'none':
+        if normalize_tag_id(form_data.name) == 'none':
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT("Tag name cannot be 'None'"),
             )
 
-        if tag_id not in tags:
-            await Chats.add_chat_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
-
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
-        tags = chat.meta.get('tags', [])
-        return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
+        # add_chat_tag uses ON CONFLICT DO NOTHING, so no pre-check needed.
+        await Chats.add_chat_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
+        return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())
 
@@ -1375,9 +1364,7 @@ async def delete_tag_by_id_and_tag_name(
         if await Chats.count_chats_by_tag_name_and_user_id(form_data.name, user.id, db=db) == 0:
             await Tags.delete_tag_by_name_and_user_id(form_data.name, user.id, db=db)
 
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
-        tags = chat.meta.get('tags', [])
-        return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
+        return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
@@ -1393,9 +1380,11 @@ async def delete_all_tags_by_id(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        old_tags = chat.meta.get('tags', [])
+        # Snapshot current tag_ids before clearing so orphan cleanup knows
+        # which tags to re-count.
+        old_tag_ids = await Chats.get_chat_tag_ids_by_id_and_user_id(id, user.id, db=db)
         await Chats.delete_all_tags_by_id_and_user_id(id, user.id, db=db)
-        await Chats.delete_orphan_tags_for_user(old_tags, user.id, db=db)
+        await Chats.delete_orphan_tags_for_user(old_tag_ids, user.id, db=db)
 
         return True
     else:

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1370,8 +1370,11 @@ async def delete_tag_by_id_and_tag_name(
     if chat:
         await Chats.delete_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
 
-        if await Chats.count_chats_by_tag_name_and_user_id(form_data.name, user.id, db=db) == 0:
-            await Tags.delete_tag_by_name_and_user_id(form_data.name, user.id, db=db)
+        # Orphan cleanup counts archived chats too (see delete_orphan_tags_for_user),
+        # so a tag referenced only by archived chats is preserved for unarchive.
+        await Chats.delete_orphan_tags_for_user(
+            [normalize_tag_id(form_data.name)], user.id, db=db
+        )
 
         return await Chats.get_chat_tags_by_id_and_user_id(id, user.id, db=db)
     else:


### PR DESCRIPTION
Adds a normalized chat_tag(chat_id, tag_id, user_id) table with composite FK to tag(id, user_id) and migrates tags from chat.meta['tags'] into it. Keeps meta['tags'] as a dual-write fallback so the change is rollback-safe.

The backfill uses keyset pagination with per-chunk fetchall() rather than yield_per streaming, so no server-side cursor stays open across the loop. Prior large-backfill migrations held a single cursor for the full run, which caused OOM / connection resets on very large PostgreSQL deployments.

Model-layer reads and writes for chat tags now go through chat_tag; the dialect-specific JSON-path filtering in get_chat_list_by_user_id_and_tag_name and count_chats_by_tag_name_and_user_id is replaced with a simple JOIN.

