### PR TITLE
fix: log expected fetch/transcript/tool-server failures as warnings

### DIFF
--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -98,7 +98,9 @@ class YoutubeLoader:
         try:
             transcript_list = transcript_api.list(self.video_id)
         except Exception as e:
-            log.exception('Loading YouTube transcript failed')
+            # Expected for age-restricted videos, disabled transcripts, or
+            # videos without captions; not a code failure.
+            log.warning(f'Loading YouTube transcript failed: {e}')
             return []
 
         # Try each language in order of priority

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -98,8 +98,6 @@ class YoutubeLoader:
         try:
             transcript_list = transcript_api.list(self.video_id)
         except Exception as e:
-            # Expected for age-restricted videos, disabled transcripts, or
-            # videos without captions; not a code failure.
             log.warning(f'Loading YouTube transcript failed: {e}')
             return []
 

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -272,7 +272,10 @@ async def fetch_url(
 
         return content
     except Exception as e:
-        log.exception(f'fetch_url error: {e}')
+        # Most failures here are expected bad input (invalid URL, YouTube
+        # video with no/age-restricted transcript) already surfaced to the
+        # model via the returned error, so don't log a full traceback.
+        log.warning(f'fetch_url error: {e}')
         return json.dumps({'error': str(e)})
 
 

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -272,9 +272,6 @@ async def fetch_url(
 
         return content
     except Exception as e:
-        # Most failures here are expected bad input (invalid URL, YouTube
-        # video with no/age-restricted transcript) already surfaced to the
-        # model via the returned error, so don't log a full traceback.
         log.warning(f'fetch_url error: {e}')
         return json.dumps({'error': str(e)})
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1326,6 +1326,15 @@ async def get_tool_servers_data(servers: list[dict[str, Any]]) -> list[dict[str,
     return results
 
 
+class ToolServerHTTPError(Exception):
+    """Tool server returned a non-2xx HTTP status.
+
+    Expected, model-recoverable condition (e.g. 404 for a path the model
+    guessed wrong) rather than a transport/code failure, so it is logged
+    without a traceback.
+    """
+
+
 async def execute_tool_server(
     url: str,
     headers: dict[str, str],
@@ -1434,7 +1443,7 @@ async def execute_tool_server(
                 ) as response:
                     if response.status >= 400:
                         text = await response.text()
-                        raise Exception(f'HTTP error {response.status}: {text}')
+                        raise ToolServerHTTPError(f'HTTP error {response.status}: {text}')
 
                     try:
                         response_data = await response.json()
@@ -1459,7 +1468,7 @@ async def execute_tool_server(
                 ) as response:
                     if response.status >= 400:
                         text = await response.text()
-                        raise Exception(f'HTTP error {response.status}: {text}')
+                        raise ToolServerHTTPError(f'HTTP error {response.status}: {text}')
 
                     try:
                         response_data = await response.json()
@@ -1475,6 +1484,10 @@ async def execute_tool_server(
                     response_headers = response.headers
                     return (response_data, response_headers)
 
+    except ToolServerHTTPError as err:
+        error = str(err)
+        log.warning(f'API Request Error: {error}')
+        return ({'error': error}, None)
     except Exception as err:
         error = str(err)
         log.exception(f'API Request Error: {error}')

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1326,15 +1326,6 @@ async def get_tool_servers_data(servers: list[dict[str, Any]]) -> list[dict[str,
     return results
 
 
-class ToolServerHTTPError(Exception):
-    """Tool server returned a non-2xx HTTP status.
-
-    Expected, model-recoverable condition (e.g. 404 for a path the model
-    guessed wrong) rather than a transport/code failure, so it is logged
-    without a traceback.
-    """
-
-
 async def execute_tool_server(
     url: str,
     headers: dict[str, str],
@@ -1443,7 +1434,7 @@ async def execute_tool_server(
                 ) as response:
                     if response.status >= 400:
                         text = await response.text()
-                        raise ToolServerHTTPError(f'HTTP error {response.status}: {text}')
+                        raise Exception(f'HTTP error {response.status}: {text}')
 
                     try:
                         response_data = await response.json()
@@ -1468,7 +1459,7 @@ async def execute_tool_server(
                 ) as response:
                     if response.status >= 400:
                         text = await response.text()
-                        raise ToolServerHTTPError(f'HTTP error {response.status}: {text}')
+                        raise Exception(f'HTTP error {response.status}: {text}')
 
                     try:
                         response_data = await response.json()
@@ -1484,13 +1475,9 @@ async def execute_tool_server(
                     response_headers = response.headers
                     return (response_data, response_headers)
 
-    except ToolServerHTTPError as err:
-        error = str(err)
-        log.warning(f'API Request Error: {error}')
-        return ({'error': error}, None)
     except Exception as err:
         error = str(err)
-        log.exception(f'API Request Error: {error}')
+        log.warning(f'API Request Error: {error}')
         return ({'error': error}, None)
 
 


### PR DESCRIPTION
## Summary

Several tool/loader code paths fail routinely on **bad input**, not on bugs:

- the model passes a non-URL (e.g. a file UUID) to `fetch_url`
- a YouTube video has no transcript / is age-restricted / has captions disabled
- a tool server returns `404 File not found` / `Directory not found` for a path the model guessed wrong (it then retries other paths)

In every case the error is already caught and surfaced back to the model as a normal error result. But these handlers used `log.exception`, which emits full multi-frame (loguru-annotated) tracebacks that look like crashes and bury real errors in the logs.

This downgrades those handlers to `log.warning`. No behavior change — the error payloads returned to the caller/model are identical; only the log severity changes.

## Changes (3 one-line edits)

- `tools/builtin.py` — `fetch_url`: `log.exception` → `log.warning`
- `retrieval/loaders/youtube.py` — `YoutubeLoader.load`: `log.exception` → `log.warning` (now includes the exception message)
- `utils/tools.py` — `execute_tool_server`: `log.exception` → `log.warning`

## Not included

The `search_knowledge_files` Postgres `invalid memory alloc request size` crash seen in the same logs is **already fixed** on `dev` (`models/knowledge.py` now uses `File.data['content'].as_string()` / `->>` per #24670); those log lines are from an older build.

## Test plan

- [ ] `fetch_url` with an invalid URL and with a YouTube link lacking a transcript → single `WARNING` line, no traceback; model still receives the error JSON.
- [ ] Tool-server call to a missing path → `WARNING` line, model receives `{'error': 'HTTP error 404: ...'}`.

https://claude.ai/code/session_01XZ7mvBjb8kEXzz3tnikeaR