### PR TITLE
perf: Optimize user_count query for licensed-seats banner

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2341,11 +2341,21 @@ async def get_app_config(request: Request):
         if data is not None and 'id' in data:
             user = await Users.get_user_by_id(data['id'])
 
-    user_count = await Users.get_num_users()
     onboarding = False
-
     if user is None:
-        onboarding = user_count == 0
+        onboarding = not await Users.has_users()
+
+    # user_count is only consumed by the licensed-seats banner, so skip the
+    # full table count unless a seat-limited license is actually configured.
+    user_count = None
+    license_metadata = app.state.LICENSE_METADATA
+    if (
+        user is not None
+        and user.role in ['admin', 'user']
+        and license_metadata
+        and license_metadata.get('seats') is not None
+    ):
+        user_count = await Users.get_num_users()
 
     return {
         **({'onboarding': True} if onboarding else {}),
@@ -2411,7 +2421,7 @@ async def get_app_config(request: Request):
                 'default_models': app.state.config.DEFAULT_MODELS,
                 'default_pinned_models': app.state.config.DEFAULT_PINNED_MODELS,
                 'default_prompt_suggestions': app.state.config.DEFAULT_PROMPT_SUGGESTIONS,
-                'user_count': user_count,
+                **({'user_count': user_count} if user_count is not None else {}),
                 'code': {
                     'engine': app.state.config.CODE_EXECUTION_ENGINE,
                     'interpreter_engine': app.state.config.CODE_INTERPRETER_ENGINE,


### PR DESCRIPTION
# Description

This PR optimizes the `get_app_config` endpoint to avoid unnecessary full table scans when counting users. The `user_count` is only consumed by the licensed-seats banner, so we now skip the expensive `get_num_users()` query unless a seat-limited license is actually configured.

## Changes

- Replace `get_num_users()` call for onboarding detection with a more efficient `has_users()` check
- Conditionally fetch `user_count` only when:
  - User is authenticated
  - User has admin or user role
  - A seat-limited license is configured
- Conditionally include `user_count` in response only when it has been fetched

This reduces unnecessary database queries on every config request for instances without seat-limited licenses.

## Changelog

### Changed
- Optimized `get_app_config` endpoint to skip user count query unless a seat-limited license is configured
- Replaced full user count with existence check for onboarding detection

### Fixed
- Reduced unnecessary database queries in `get_app_config` endpoint

---

### Additional Information

The change maintains backward compatibility by conditionally including `user_count` in the response only when it's relevant (seat-limited license configured). Clients that don't use the licensed-seats banner won't be affected by the absence of this field.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

https://claude.ai/code/session_01LHQq7F3jJhhHi3ivuVrTmf