### PR TITLE
BREAKING/perf/feat: cache-optimal file context in native FC mode

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1412,8 +1412,8 @@ Respond to the user query using the provided context, incorporating inline citat
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
 - **For `<source>` tags in the context: only include inline citations using [id] (e.g., [1], [2]) when the `<source>` tag includes an id attribute, and do not cite from `<source>` tags that lack an id attribute.**
-- **Do not cite `<attached_file>` entries** — they are inventory listings of retrievable items, not evidence. To use an attached file as evidence, first call `query_attached_files` to retrieve its content, then cite from the returned chunks.
 - **For tool result chunks (which do not arrive wrapped in `<source>` tags):** cite using the chunk's source identifier in square brackets — typically the `source` filename, e.g. `[contract.pdf]`. Do not invent numeric `[N]` citations for tool result content that doesn't carry one.
+- If the context lists items as available for retrieval but does not include their content (for example, inventory-style entries), do not cite them directly — call the appropriate tool to fetch their content first, then cite from the returned chunks.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1413,7 +1413,8 @@ Respond to the user query using the provided context, incorporating inline citat
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
 - **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
 - Do not cite if the <source> tag does not contain an id attribute.
-- **Do not cite `<attached_file>` entries** — they are inventory listings of retrievable items, not evidence. To use an attached file as evidence, first call `query_attached_files` to retrieve its content, then cite from the returned `<source id="...">` tags.
+- **Do not cite `<attached_file>` entries** — they are inventory listings of retrievable items, not evidence. To use an attached file as evidence, first call `query_attached_files` to retrieve its content, then cite from the returned chunks.
+- **Tool result content is also citeable.** Tool results (e.g. from `query_attached_files` or `query_knowledge_files`) return chunks with `source` (filename) and `file_id` fields, or sometimes `<source id="...">` tags wrapping the content. Cite by the source identifier — `[source-name]` (e.g. `[contract.pdf]`) when only a name is present, or `[id]` when a numeric `<source id="...">` is present. Do not invent numeric `[N]` citations for content that doesn't carry one.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1413,6 +1413,7 @@ Respond to the user query using the provided context, incorporating inline citat
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
 - **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
 - Do not cite if the <source> tag does not contain an id attribute.
+- **Do not cite `<attached_file>` entries** — they are inventory listings of retrievable items, not evidence. To use an attached file as evidence, first call `query_attached_files` to retrieve its content, then cite from the returned `<source id="...">` tags.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1411,10 +1411,9 @@ Respond to the user query using the provided context, incorporating inline citat
 - Respond in the same language as the user's query.
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
-- **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
-- Do not cite if the <source> tag does not contain an id attribute.
+- **For `<source>` tags in the context: only include inline citations using [id] (e.g., [1], [2]) when the `<source>` tag includes an id attribute, and do not cite from `<source>` tags that lack an id attribute.**
 - **Do not cite `<attached_file>` entries** — they are inventory listings of retrievable items, not evidence. To use an attached file as evidence, first call `query_attached_files` to retrieve its content, then cite from the returned chunks.
-- **Tool result content is also citeable.** Tool results (e.g. from `query_attached_files` or `query_knowledge_files`) return chunks with `source` (filename) and `file_id` fields, or sometimes `<source id="...">` tags wrapping the content. Cite by the source identifier — `[source-name]` (e.g. `[contract.pdf]`) when only a name is present, or `[id]` when a numeric `<source id="...">` is present. Do not invent numeric `[N]` citations for content that doesn't carry one.
+- **For tool result chunks (which do not arrive wrapped in `<source>` tags):** cite using the chunk's source identifier in square brackets — typically the `source` filename, e.g. `[contract.pdf]`. Do not invent numeric `[N]` citations for tool result content that doesn't carry one.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 
@@ -1423,7 +1422,7 @@ If the user asks about a specific topic and the information is found in a source
 * "According to the study, the proposed method increases efficiency by 20% [1]."
 
 ### Output:
-Provide a clear and direct response to the user's query, including inline citations in the format [id] only when the <source> tag with id attribute is present in the context.
+Provide a clear and direct response to the user's query. Use inline citations in [id] format when an `<source id="...">` tag is present in the context, or in [source-name] format when citing a chunk returned by a tool result.
 
 <context>
 {{CONTEXT}}

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -567,6 +567,7 @@ from open_webui.utils.models import (
     get_all_models,
     get_filtered_models,
 )
+from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
 from open_webui.utils.oauth import (
     OAuthClientInformationFull,
     OAuthClientManager,
@@ -1047,6 +1048,7 @@ app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT = RAG_EXTERNAL_RERANKER_TIMEOUT
 app.state.config.RAG_RERANKING_BATCH_SIZE = RAG_RERANKING_BATCH_SIZE
 
 app.state.config.RAG_TEMPLATE = RAG_TEMPLATE
+warn_if_deprecated_rag_template_placeholders(app.state.config.RAG_TEMPLATE)
 
 app.state.config.RAG_OPENAI_API_BASE_URL = RAG_OPENAI_API_BASE_URL
 app.state.config.RAG_OPENAI_API_KEY = RAG_OPENAI_API_KEY

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -718,6 +718,9 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
     request.app.state.config.RAG_TEMPLATE = (
         form_data.RAG_TEMPLATE if form_data.RAG_TEMPLATE is not None else request.app.state.config.RAG_TEMPLATE
     )
+    from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
+
+    warn_if_deprecated_rag_template_placeholders(request.app.state.config.RAG_TEMPLATE)
     request.app.state.config.TOP_K = form_data.TOP_K if form_data.TOP_K is not None else request.app.state.config.TOP_K
     request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL = (
         form_data.BYPASS_EMBEDDING_AND_RETRIEVAL

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2532,7 +2532,10 @@ async def query_attached_files(
         user_role = __user__.get('role', 'user')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
 
-        if ids is not None:
+        # Empty list and missing field both mean "no scoping" — search every
+        # attached item. Only an explicit non-empty list that resolves to
+        # nothing is treated as a model error.
+        if ids:
             scoped_items = [item for item in __attached_files__ if item.get('id') in ids]
             if not scoped_items:
                 return json.dumps({

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2532,22 +2532,23 @@ async def query_attached_files(
         user_role = __user__.get('role', 'user')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
 
-        if ids:
+        if ids is not None:
             scoped_items = [item for item in __attached_files__ if item.get('id') in ids]
             if not scoped_items:
                 return json.dumps({
                     'error': 'None of the requested ids match an attached file. '
-                    'Check the <attached_file id="..."> entries in <available_files>.'
+                    'Check the <attached_file id="..."> entries in <available_files>, '
+                    'or omit `ids` to search every attached item.'
                 })
         else:
             scoped_items = list(__attached_files__)
 
-        # Resolve each attached item to one or more collection names AFTER
-        # verifying the caller can actually read it. Items the user can't
-        # access are silently skipped (same posture as query_knowledge_files).
-        # full-context items are already in the system prompt; skip defensively.
-        collection_names: list[str] = []
+        # Resolve each attached item to collection names AFTER verifying the
+        # caller can read it. Items the user can't access are silently skipped
+        # (same posture as query_knowledge_files).
+        collection_names = []
         for attached_item in scoped_items:
+            # Belt-and-suspenders: callers already filter context == 'full'.
             if attached_item.get('context') == 'full':
                 continue
             item_type = attached_item.get('type')
@@ -2559,6 +2560,8 @@ async def query_attached_files(
                 file_record = await Files.get_file_by_id(item_id)
                 if not file_record:
                     continue
+                # Chat scope: deliberately do not pass __model_knowledge__ —
+                # this tool only reads items the user attached to *this* chat.
                 if not await _has_read_access_to_file(file_record, user_id, user_role):
                     continue
                 collection_names.append(f'file-{item_id}')
@@ -2589,11 +2592,7 @@ async def query_attached_files(
                 'error': 'No accessible retrievable collections resolved from the attached items.'
             })
 
-        seen_collection_names: set = set()
-        collection_names = [
-            name for name in collection_names
-            if not (name in seen_collection_names or seen_collection_names.add(name))
-        ]
+        collection_names = list(dict.fromkeys(collection_names))
 
         chunks: list[dict] = []
         query_results = await query_collection(

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2512,13 +2512,19 @@ async def query_attached_files(
                 ids = [ids]
 
     try:
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.models.files import Files
+        from open_webui.models.knowledge import Knowledges
         from open_webui.retrieval.utils import query_collection
 
         embedding_function = __request__.app.state.EMBEDDING_FUNCTION
         if not embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
 
-        # Honor optional scoping by id; otherwise search everything attached.
+        user_id = __user__.get('id')
+        user_role = __user__.get('role', 'user')
+        user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
+
         if ids:
             scoped_items = [item for item in __attached_files__ if item.get('id') in ids]
             if not scoped_items:
@@ -2529,31 +2535,58 @@ async def query_attached_files(
         else:
             scoped_items = list(__attached_files__)
 
-        # file -> file-{id}; collection -> {id} or explicit collection_names.
+        # Resolve each attached item to one or more collection names AFTER
+        # verifying the caller can actually read it. Items the user can't
+        # access are silently skipped (same posture as query_knowledge_files).
         # full-context items are already in the system prompt; skip defensively.
         collection_names: list[str] = []
-        for item in scoped_items:
-            if item.get('context') == 'full':
+        for attached_item in scoped_items:
+            if attached_item.get('context') == 'full':
                 continue
-            item_type = item.get('type')
-            item_id = item.get('id')
+            item_type = attached_item.get('type')
+            item_id = attached_item.get('id')
             if not item_id:
                 continue
+
             if item_type == 'file':
+                file_record = await Files.get_file_by_id(item_id)
+                if not file_record:
+                    continue
+                if not await _has_read_access_to_file(file_record, user_id, user_role):
+                    continue
                 collection_names.append(f'file-{item_id}')
+
             elif item_type == 'collection':
-                explicit_names = item.get('collection_names')
-                if explicit_names:
-                    collection_names.extend(explicit_names)
+                knowledge_record = await Knowledges.get_knowledge_by_id(item_id)
+                user_owns_kb = knowledge_record and (
+                    user_role == 'admin'
+                    or knowledge_record.user_id == user_id
+                    or await AccessGrants.has_access(
+                        user_id=user_id,
+                        resource_type='knowledge',
+                        resource_id=knowledge_record.id,
+                        permission='read',
+                        user_group_ids=set(user_group_ids),
+                    )
+                )
+                if not user_owns_kb:
+                    continue
+                explicit_collection_names = attached_item.get('collection_names')
+                if explicit_collection_names:
+                    collection_names.extend(explicit_collection_names)
                 else:
                     collection_names.append(item_id)
 
         if not collection_names:
-            return json.dumps({'error': 'No retrievable collections resolved from the attached items.'})
+            return json.dumps({
+                'error': 'No accessible retrievable collections resolved from the attached items.'
+            })
 
-        # De-duplicate while preserving order.
-        seen: set = set()
-        collection_names = [n for n in collection_names if not (n in seen or seen.add(n))]
+        seen_collection_names: set = set()
+        collection_names = [
+            name for name in collection_names
+            if not (name in seen_collection_names or seen_collection_names.add(name))
+        ]
 
         chunks: list[dict] = []
         query_results = await query_collection(
@@ -2565,19 +2598,19 @@ async def query_attached_files(
         )
 
         if query_results and 'documents' in query_results:
-            documents = query_results.get('documents', [[]])[0]
-            metadatas = query_results.get('metadatas', [[]])[0]
-            distances = query_results.get('distances', [[]])[0]
+            chunk_documents = query_results.get('documents', [[]])[0]
+            chunk_metadatas = query_results.get('metadatas', [[]])[0]
+            chunk_distances = query_results.get('distances', [[]])[0]
 
-            for idx, doc in enumerate(documents):
-                meta = metadatas[idx] if idx < len(metadatas) else {}
+            for chunk_index, document in enumerate(chunk_documents):
+                chunk_metadata = chunk_metadatas[chunk_index] if chunk_index < len(chunk_metadatas) else {}
                 chunk_info = {
-                    'content': doc,
-                    'source': meta.get('source') or meta.get('name') or 'Unknown',
-                    'file_id': meta.get('file_id', ''),
+                    'content': document,
+                    'source': chunk_metadata.get('source') or chunk_metadata.get('name') or 'Unknown',
+                    'file_id': chunk_metadata.get('file_id', ''),
                 }
-                if idx < len(distances):
-                    chunk_info['distance'] = distances[idx]
+                if chunk_index < len(chunk_distances):
+                    chunk_info['distance'] = chunk_distances[chunk_index]
                 chunks.append(chunk_info)
 
         chunks = chunks[:count]

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -64,10 +64,8 @@ async def _has_read_access_to_file(
     from open_webui.models.users import Users
     from open_webui.utils.access_control.files import has_access_to_file
 
-    # has_access_to_file needs a real UserModel (it reads user.id and resolves
-    # the user's groups). Fetch by PK — a cheap identity-map lookup — instead
-    # of synthesizing a partial UserModel, which fails validation on the
-    # required email/name/timestamp fields.
+    # Fetch the real user (cheap PK lookup); a synthesized partial UserModel
+    # fails validation on the required email/name/timestamp fields.
     user = await Users.get_user_by_id(user_id)
     if not user:
         return False
@@ -2328,10 +2326,8 @@ async def query_knowledge_files(
         if knowledge_ids.lower() in ('none', 'null', ''):
             knowledge_ids = None
         else:
-            # Try to parse as JSON array if it looks like one. Wrap scalar
-            # parse results (e.g. '"abc"' → 'abc') in a list so downstream
-            # membership checks stay list-shaped instead of degenerating
-            # into substring or dict-key matching.
+            # Wrap scalar parse results (e.g. '"abc"' -> 'abc') in a list so
+            # membership checks stay list-shaped, not substring/dict-key matching.
             try:
                 parsed = json.loads(knowledge_ids)
                 knowledge_ids = parsed if isinstance(parsed, list) else [parsed]
@@ -2528,10 +2524,8 @@ async def query_attached_files(
         else:
             try:
                 parsed = json.loads(ids)
-                # JSON can deserialize to dict / scalar / list — only a list
-                # is valid for membership scoping. Wrap scalars in a list so
-                # `item.get('id') in ids` stays a list membership check
-                # (not a string substring check or dict-key lookup).
+                # Wrap non-list parses in a list so `id in ids` stays a list
+                # membership check (not substring/dict-key matching).
                 ids = parsed if isinstance(parsed, list) else [parsed]
             except json.JSONDecodeError:
                 ids = [ids]

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -61,11 +61,17 @@ async def _has_read_access_to_file(
         for item in model_knowledge
     ):
         return True
+    from open_webui.models.users import Users
     from open_webui.utils.access_control.files import has_access_to_file
-    return await has_access_to_file(
-        file_id=file.id, access_type='read',
-        user=UserModel(**{'id': user_id, 'role': user_role}),
-    )
+
+    # has_access_to_file needs a real UserModel (it reads user.id and resolves
+    # the user's groups). Fetch by PK — a cheap identity-map lookup — instead
+    # of synthesizing a partial UserModel, which fails validation on the
+    # required email/name/timestamp fields.
+    user = await Users.get_user_by_id(user_id)
+    if not user:
+        return False
+    return await has_access_to_file(file_id=file.id, access_type='read', user=user)
 
 # =============================================================================
 # TIME UTILITIES
@@ -2503,7 +2509,7 @@ async def query_attached_files(
     if not __attached_files__:
         return json.dumps({'error': 'No retrievable files are attached to this chat.'})
 
-    admin_top_k = getattr(__request__.app.state.config, 'TOP_K', 5) or 5
+    admin_top_k = __request__.app.state.config.TOP_K
 
     if isinstance(count, str):
         try:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2322,9 +2322,13 @@ async def query_knowledge_files(
         if knowledge_ids.lower() in ('none', 'null', ''):
             knowledge_ids = None
         else:
-            # Try to parse as JSON array if it looks like one
+            # Try to parse as JSON array if it looks like one. Wrap scalar
+            # parse results (e.g. '"abc"' → 'abc') in a list so downstream
+            # membership checks stay list-shaped instead of degenerating
+            # into substring or dict-key matching.
             try:
-                knowledge_ids = json.loads(knowledge_ids)
+                parsed = json.loads(knowledge_ids)
+                knowledge_ids = parsed if isinstance(parsed, list) else [parsed]
             except json.JSONDecodeError:
                 # Treat as single ID
                 knowledge_ids = [knowledge_ids]
@@ -2478,12 +2482,14 @@ async def query_attached_files(
     """
     Search files and knowledge bases the user attached to this chat.
 
-    Items appear in the system context inside <available_files> as
-    <attached_file id="..."> entries. Distinct from query_knowledge_files
+    The system context lists each retrievable item inside <retrievable_files>
+    as a <retrievable_file id="..."> entry. Call this tool to fetch
+    semantically relevant chunks; cite from the returned chunks rather than
+    the inventory entries themselves. Distinct from query_knowledge_files
     (which searches model-attached knowledge).
 
     :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
-    :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on an `<attached_file id="...">` entry in the system context (for example "abc123" for `<attached_file id="abc123" ...>`, not the whole tag).
+    :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on a `<retrievable_file id="...">` entry in the system context (for example "abc123" for `<retrievable_file id="abc123" ...>`, not the whole tag).
     :param count: Optional. Maximum number of result chunks to return. When omitted, defaults to the admin-configured retrieval TOP_K. When supplied, values above that limit are clamped down.
     :return: JSON list of chunks with content, source, file_id, distance
     """
@@ -2514,7 +2520,12 @@ async def query_attached_files(
             ids = None
         else:
             try:
-                ids = json.loads(ids)
+                parsed = json.loads(ids)
+                # JSON can deserialize to dict / scalar / list — only a list
+                # is valid for membership scoping. Wrap scalars in a list so
+                # `item.get('id') in ids` stays a list membership check
+                # (not a string substring check or dict-key lookup).
+                ids = parsed if isinstance(parsed, list) else [parsed]
             except json.JSONDecodeError:
                 ids = [ids]
 
@@ -2540,7 +2551,7 @@ async def query_attached_files(
             if not scoped_items:
                 return json.dumps({
                     'error': 'None of the requested ids match an attached file. '
-                    'Check the <attached_file id="..."> entries in <available_files>, '
+                    'Check the <retrievable_file id="..."> entries in <retrievable_files>, '
                     'or omit `ids` to search every attached item.'
                 })
         else:
@@ -2613,7 +2624,13 @@ async def query_attached_files(
             chunk_distances = query_results.get('distances', [[]])[0]
 
             for chunk_index, document in enumerate(chunk_documents):
-                chunk_metadata = chunk_metadatas[chunk_index] if chunk_index < len(chunk_metadatas) else {}
+                # Some query_collection paths can return None in the
+                # metadatas list (e.g. partial hybrid-search failures).
+                chunk_metadata = (
+                    chunk_metadatas[chunk_index]
+                    if chunk_index < len(chunk_metadatas)
+                    else None
+                ) or {}
                 chunk_info = {
                     'content': document,
                     'source': chunk_metadata.get('source') or chunk_metadata.get('name') or 'Unknown',

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2467,6 +2467,138 @@ async def query_knowledge_files(
         return json.dumps({'error': str(e)})
 
 
+async def query_attached_files(
+    query: str,
+    ids: Optional[list[str]] = None,
+    count: int = 5,
+    __request__: Request = None,
+    __user__: dict = None,
+    __attached_files__: list[dict] = None,
+) -> str:
+    """
+    Search the files and knowledge bases the user attached to THIS chat.
+
+    Use this when the user references a document they uploaded or a knowledge
+    base they attached to the conversation and you need its content to answer.
+    Items appear in the system context inside <available_files> as
+    <attached_file id="..."> entries — pass those ids in `ids` to scope the
+    search, or omit `ids` to search all attached items.
+
+    This is distinct from query_knowledge_files, which searches knowledge
+    attached to the model itself.
+
+    :param query: The search query to find semantically relevant content within the user's attached files
+    :param ids: Optional list of attached_file ids (from <attached_file id="...">) to limit the search to. Omit to search all attached items.
+    :param count: Maximum number of chunks to return (default: 5)
+    :return: JSON list of chunks with content, source filename, file id, and relevance score
+    """
+    if __request__ is None:
+        return json.dumps({'error': 'Request context not available'})
+
+    if not __user__:
+        return json.dumps({'error': 'User context not available'})
+
+    if not __attached_files__:
+        return json.dumps({'error': 'No retrievable files are attached to this chat.'})
+
+    if isinstance(count, str):
+        try:
+            count = int(count)
+        except ValueError:
+            count = 5
+
+    if isinstance(ids, str):
+        if ids.lower() in ('none', 'null', ''):
+            ids = None
+        else:
+            try:
+                ids = json.loads(ids)
+            except json.JSONDecodeError:
+                ids = [ids]
+
+    try:
+        from open_webui.retrieval.utils import query_collection
+
+        embedding_function = __request__.app.state.EMBEDDING_FUNCTION
+        if not embedding_function:
+            return json.dumps({'error': 'Embedding function not configured'})
+
+        # Honor optional scoping by id; otherwise search everything attached.
+        if ids:
+            scoped_items = [item for item in __attached_files__ if item.get('id') in ids]
+            if not scoped_items:
+                return json.dumps({
+                    'error': 'None of the requested ids match an attached file. '
+                    'Check the <attached_file id="..."> entries in <available_files>.'
+                })
+        else:
+            scoped_items = list(__attached_files__)
+
+        # Build collection_names per item:
+        #  - type 'file'       -> file-{id}
+        #  - type 'collection' -> {id} (knowledge base id is the collection name)
+        # Items with context='full' are already injected into the system
+        # prompt and should not have been registered here, but we filter
+        # defensively in case middleware policy changes.
+        collection_names: list[str] = []
+        for item in scoped_items:
+            if item.get('context') == 'full':
+                continue
+            item_type = item.get('type')
+            item_id = item.get('id')
+            if not item_id:
+                continue
+            if item_type == 'file':
+                collection_names.append(f'file-{item_id}')
+            elif item_type == 'collection':
+                # Knowledge bases may carry an explicit list of collection_names
+                # (legacy / multi-collection KBs); use them when present,
+                # otherwise fall back to the KB id.
+                explicit_names = item.get('collection_names')
+                if explicit_names:
+                    collection_names.extend(explicit_names)
+                else:
+                    collection_names.append(item_id)
+
+        if not collection_names:
+            return json.dumps({'error': 'No retrievable collections resolved from the attached items.'})
+
+        # De-duplicate while preserving order.
+        seen: set = set()
+        collection_names = [n for n in collection_names if not (n in seen or seen.add(n))]
+
+        chunks: list[dict] = []
+        query_results = await query_collection(
+            __request__,
+            collection_names=collection_names,
+            queries=[query],
+            embedding_function=embedding_function,
+            k=count,
+        )
+
+        if query_results and 'documents' in query_results:
+            documents = query_results.get('documents', [[]])[0]
+            metadatas = query_results.get('metadatas', [[]])[0]
+            distances = query_results.get('distances', [[]])[0]
+
+            for idx, doc in enumerate(documents):
+                meta = metadatas[idx] if idx < len(metadatas) else {}
+                chunk_info = {
+                    'content': doc,
+                    'source': meta.get('source') or meta.get('name') or 'Unknown',
+                    'file_id': meta.get('file_id', ''),
+                }
+                if idx < len(distances):
+                    chunk_info['distance'] = distances[idx]
+                chunks.append(chunk_info)
+
+        chunks = chunks[:count]
+        return json.dumps(chunks, ensure_ascii=False)
+    except Exception as e:
+        log.exception(f'query_attached_files error: {e}')
+        return json.dumps({'error': str(e)})
+
+
 async def query_knowledge_bases(
     query: str,
     count: int = 5,

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2478,13 +2478,13 @@ async def query_attached_files(
     """
     Search files and knowledge bases the user attached to this chat.
 
-    Items appear in the system context as <attached_file id="..."> entries
-    inside <available_files>. Pass those ids to scope, or omit to search all.
-    Distinct from query_knowledge_files (which searches model-attached knowledge).
+    Items appear in the system context inside <available_files> as
+    <attached_file id="..."> entries. Distinct from query_knowledge_files
+    (which searches model-attached knowledge).
 
-    :param query: Search query for semantically relevant content
-    :param ids: Optional list of <attached_file id="..."> ids to limit the search
-    :param count: Optional max chunks; defaults to the admin-configured retrieval TOP_K, and any value above that cap is clamped down
+    :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
+    :param ids: Optional. List of plain attached-item id strings to scope the search to a subset of items. Each id is the literal value of the `id` attribute on an `<attached_file id="...">` entry in the system context (for example "abc123" for `<attached_file id="abc123" ...>`, not the whole tag). Omit to search every attached item.
+    :param count: Optional. Maximum number of result chunks to return. When omitted, defaults to the admin-configured retrieval TOP_K. When supplied, values above that limit are clamped down.
     :return: JSON list of chunks with content, source, file_id, distance
     """
     if __request__ is None:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2453,10 +2453,11 @@ async def query_knowledge_files(
                 distances = query_results.get('distances', [[]])[0]
 
                 for idx, doc in enumerate(documents):
+                    meta = (metadatas[idx] if idx < len(metadatas) else None) or {}
                     chunk_info = {
                         'content': doc,
-                        'source': metadatas[idx].get('source', metadatas[idx].get('name', 'Unknown')),
-                        'file_id': metadatas[idx].get('file_id', ''),
+                        'source': meta.get('source') or meta.get('name') or 'Unknown',
+                        'file_id': meta.get('file_id', ''),
                     }
                     if idx < len(distances):
                         chunk_info['distance'] = distances[idx]
@@ -2595,11 +2596,9 @@ async def query_attached_files(
                 )
                 if not user_owns_kb:
                     continue
-                # Use the KB id directly as the collection name. Matches
-                # query_knowledge_files. The previous fallback that trusted
-                # attached_item['collection_names'] was a BOLA — a caller
-                # could legitimately own KB X but supply collection_names
-                # like ['file-<victim_id>'] and read unrelated collections.
+                # Use the access-checked KB id directly (matches
+                # query_knowledge_files). Trusting client-supplied
+                # collection_names here would be a BOLA.
                 collection_names.append(item_id)
 
         if not collection_names:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2476,21 +2476,16 @@ async def query_attached_files(
     __attached_files__: list[dict] = None,
 ) -> str:
     """
-    Search the files and knowledge bases the user attached to THIS chat.
+    Search files and knowledge bases the user attached to this chat.
 
-    Use this when the user references a document they uploaded or a knowledge
-    base they attached to the conversation and you need its content to answer.
-    Items appear in the system context inside <available_files> as
-    <attached_file id="..."> entries — pass those ids in `ids` to scope the
-    search, or omit `ids` to search all attached items.
+    Items appear in the system context as <attached_file id="..."> entries
+    inside <available_files>. Pass those ids to scope, or omit to search all.
+    Distinct from query_knowledge_files (which searches model-attached knowledge).
 
-    This is distinct from query_knowledge_files, which searches knowledge
-    attached to the model itself.
-
-    :param query: The search query to find semantically relevant content within the user's attached files
-    :param ids: Optional list of attached_file ids (from <attached_file id="...">) to limit the search to. Omit to search all attached items.
-    :param count: Maximum number of chunks to return (default: 5)
-    :return: JSON list of chunks with content, source filename, file id, and relevance score
+    :param query: Search query for semantically relevant content
+    :param ids: Optional list of <attached_file id="..."> ids to limit the search
+    :param count: Maximum number of chunks (default: 5)
+    :return: JSON list of chunks with content, source, file_id, distance
     """
     if __request__ is None:
         return json.dumps({'error': 'Request context not available'})
@@ -2534,12 +2529,8 @@ async def query_attached_files(
         else:
             scoped_items = list(__attached_files__)
 
-        # Build collection_names per item:
-        #  - type 'file'       -> file-{id}
-        #  - type 'collection' -> {id} (knowledge base id is the collection name)
-        # Items with context='full' are already injected into the system
-        # prompt and should not have been registered here, but we filter
-        # defensively in case middleware policy changes.
+        # file -> file-{id}; collection -> {id} or explicit collection_names.
+        # full-context items are already in the system prompt; skip defensively.
         collection_names: list[str] = []
         for item in scoped_items:
             if item.get('context') == 'full':
@@ -2551,9 +2542,6 @@ async def query_attached_files(
             if item_type == 'file':
                 collection_names.append(f'file-{item_id}')
             elif item_type == 'collection':
-                # Knowledge bases may carry an explicit list of collection_names
-                # (legacy / multi-collection KBs); use them when present,
-                # otherwise fall back to the KB id.
                 explicit_names = item.get('collection_names')
                 if explicit_names:
                     collection_names.extend(explicit_names)

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2470,7 +2470,7 @@ async def query_knowledge_files(
 async def query_attached_files(
     query: str,
     ids: Optional[list[str]] = None,
-    count: int = 5,
+    count: Optional[int] = None,
     __request__: Request = None,
     __user__: dict = None,
     __attached_files__: list[dict] = None,
@@ -2484,7 +2484,7 @@ async def query_attached_files(
 
     :param query: Search query for semantically relevant content
     :param ids: Optional list of <attached_file id="..."> ids to limit the search
-    :param count: Maximum number of chunks (default: 5)
+    :param count: Optional max chunks; defaults to the admin-configured retrieval TOP_K, and any value above that cap is clamped down
     :return: JSON list of chunks with content, source, file_id, distance
     """
     if __request__ is None:
@@ -2496,11 +2496,18 @@ async def query_attached_files(
     if not __attached_files__:
         return json.dumps({'error': 'No retrievable files are attached to this chat.'})
 
+    admin_top_k = getattr(__request__.app.state.config, 'TOP_K', 5) or 5
+
     if isinstance(count, str):
         try:
             count = int(count)
         except ValueError:
-            count = 5
+            count = None
+
+    if not isinstance(count, int) or count <= 0:
+        count = admin_top_k
+    else:
+        count = min(count, admin_top_k)
 
     if isinstance(ids, str):
         if ids.lower() in ('none', 'null', ''):

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2483,7 +2483,7 @@ async def query_attached_files(
     (which searches model-attached knowledge).
 
     :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
-    :param ids: Optional. List of plain attached-item id strings to scope the search to a subset of items. Each id is the literal value of the `id` attribute on an `<attached_file id="...">` entry in the system context (for example "abc123" for `<attached_file id="abc123" ...>`, not the whole tag). Omit to search every attached item.
+    :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on an `<attached_file id="...">` entry in the system context (for example "abc123" for `<attached_file id="abc123" ...>`, not the whole tag).
     :param count: Optional. Maximum number of result chunks to return. When omitted, defaults to the admin-configured retrieval TOP_K. When supplied, values above that limit are clamped down.
     :return: JSON list of chunks with content, source, file_id, distance
     """

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2584,11 +2584,12 @@ async def query_attached_files(
                 )
                 if not user_owns_kb:
                     continue
-                explicit_collection_names = attached_item.get('collection_names')
-                if explicit_collection_names:
-                    collection_names.extend(explicit_collection_names)
-                else:
-                    collection_names.append(item_id)
+                # Use the KB id directly as the collection name. Matches
+                # query_knowledge_files. The previous fallback that trusted
+                # attached_item['collection_names'] was a BOLA — a caller
+                # could legitimately own KB X but supply collection_names
+                # like ['file-<victim_id>'] and read unrelated collections.
+                collection_names.append(item_id)
 
         if not collection_names:
             return json.dumps({

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2926,16 +2926,22 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             # add_file_context injects <attached_files> URL refs into user
             # messages — should only run when the file_context capability is
             # on, to match the rest of the file-context pipeline.
+            # __attached_files__ powers query_attached_files registration in
+            # get_builtin_tools; same gate so a model with file_context=False
+            # can't reach attached file content through the new tool either.
             if file_context_enabled:
                 chat_id = metadata.get('chat_id')
                 form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+                attached_files_for_tools = form_data.get('metadata', {}).get('files', []) or []
+            else:
+                attached_files_for_tools = []
             builtin_tools = await get_builtin_tools(
                 request,
                 {
                     **extra_params,
                     '__event_emitter__': event_emitter,
                     '__skill_ids__': [s.id for s in available_skills if s.id not in user_skill_ids],
-                    '__attached_files__': form_data.get('metadata', {}).get('files', []) or [],
+                    '__attached_files__': attached_files_for_tools,
                 },
                 features,
                 model,
@@ -2975,6 +2981,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
     )
 
+    # The new path is only meaningful when there's at least one chunked
+    # file/collection to route through query_attached_files. Without it,
+    # forcing system-prompt placement and skipping the tool-loop RAG
+    # re-application would regress citation handling for unrelated native
+    # tool calls (search_web, query_knowledge_files, view_file, etc.) in
+    # no-file or full-context-only chats.
+    attached_files_list = (form_data.get('metadata') or {}).get('files') or []
+    has_retrievable_attached_files = any(
+        item.get('context') != 'full'
+        and item.get('type') in ('file', 'collection')
+        for item in attached_files_list
+    )
+
     # Native FC + builtin tools: route chunked retrieval through
     # query_attached_files (immutable tool results = cache-stable). Gated on
     # `not payload_tools` because that branch is where builtin tools get
@@ -2987,6 +3006,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         and knowledge_builtins_enabled
         and file_context_enabled
         and not force_full_context
+        and has_retrievable_attached_files
     )
     # Read by the tool-call loop to skip per-iteration RAG re-application.
     metadata['native_fc_with_builtins'] = native_fc_with_builtins

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -216,7 +216,7 @@ def get_citation_source_from_tool_result(
 
     Returns a list of sources (usually one, but query_knowledge_files may return multiple).
     """
-    _EXPECTS_LIST = {'search_web', 'query_knowledge_files'}
+    _EXPECTS_LIST = {'search_web', 'query_knowledge_files', 'query_attached_files'}
     _EXPECTS_DICT = {'view_knowledge_file', 'view_file'}
 
     try:
@@ -305,7 +305,7 @@ def get_citation_source_from_tool_result(
                 }
             ]
 
-        elif tool_name == 'query_knowledge_files':
+        elif tool_name in ('query_knowledge_files', 'query_attached_files'):
             chunks = tool_result
 
             # Group chunks by source for better citation display
@@ -928,6 +928,9 @@ def handle_responses_streaming_event(
         return current_output, None
 
 
+_ROSTER_HINT = 'Use query_attached_files with this id to inspect or search this item.'
+
+
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
     Render sources for the RAG <context> block.
@@ -943,33 +946,33 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
     roster_parts: list[str] = []
 
     for source in sources:
-        src_meta = source.get('source') or {}
-        src_name = src_meta.get('name')
-        src_type = src_meta.get('type')
-        src_rid = src_meta.get('id')
+        source_info = source.get('source') or {}
+        source_name = source_info.get('name')
+        source_type = source_info.get('type')
+        source_resource_id = source_info.get('id')
 
         if source.get('roster_only'):
             roster_parts.append(
                 '<attached_file'
-                + (f' id="{src_rid}"' if src_rid else '')
-                + (f' name="{src_name}"' if src_name else '')
-                + (f' resource-type="{src_type}"' if src_type else '')
+                + (f' id="{source_resource_id}"' if source_resource_id else '')
+                + (f' name="{source_name}"' if source_name else '')
+                + (f' resource-type="{source_type}"' if source_type else '')
                 + ' mode="retrievable">'
-                + 'Use query_attached_files with this id to inspect or search this item.'
+                + _ROSTER_HINT
                 + '</attached_file>\n'
             )
             continue
 
-        for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = (meta or {}).get('source') or src_rid or 'N/A'
+        for document_chunk, chunk_meta in zip(source.get('document', []), source.get('metadata', [])):
+            source_id = (chunk_meta or {}).get('source') or source_resource_id or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
-            body = doc if include_content else ''
+            body = document_chunk if include_content else ''
             citeable_parts.append(
                 f'<source id="{source_ids[source_id]}"'
-                + (f' name="{src_name}"' if src_name else '')
-                + (f' resource-type="{src_type}"' if src_type else '')
-                + (f' resource-id="{src_rid}"' if src_rid else '')
+                + (f' name="{source_name}"' if source_name else '')
+                + (f' resource-type="{source_type}"' if source_type else '')
+                + (f' resource-id="{source_resource_id}"' if source_resource_id else '')
                 + f'>{body}</source>\n'
             )
 
@@ -1981,23 +1984,28 @@ async def chat_completion_files_handler(
     sources = []
 
     if files := body.get('metadata', {}).get('files', None):
-        force_full_context = request.app.state.config.RAG_FULL_CONTEXT
+        force_full_context = (
+            request.app.state.config.RAG_FULL_CONTEXT
+            or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+        )
         all_full_context = all(item.get('context') == 'full' for item in files)
 
         if native_function_calling_with_builtins and not force_full_context:
-            # Partition: full-context items + natively-full types -> retrieval;
-            # everything else -> roster-only (model queries via tool on demand).
+            # Partition once: chunked file/collection -> roster (model uses
+            # query_attached_files); everything else (full-context items,
+            # natively-full types, unknown types) -> retrieval pipeline.
             FULL_CONTENT_TYPES = {'text', 'note', 'chat', 'url'}
-            full_context_items = [
-                item
-                for item in files
-                if item.get('context') == 'full' or item.get('type') in FULL_CONTENT_TYPES
-            ]
-            retrievable_items = [
-                item
-                for item in files
-                if item not in full_context_items and item.get('type') in {'file', 'collection'}
-            ]
+            RETRIEVABLE_TYPES = {'file', 'collection'}
+            full_context_items, retrievable_items = [], []
+            for item in files:
+                if item.get('context') == 'full' or item.get('type') in FULL_CONTENT_TYPES:
+                    full_context_items.append(item)
+                elif item.get('type') in RETRIEVABLE_TYPES:
+                    retrievable_items.append(item)
+                else:
+                    # Unknown type: route through retrieval to preserve
+                    # whatever shape get_sources_from_items returns today.
+                    full_context_items.append(item)
         else:
             full_context_items = files
             retrievable_items = []
@@ -4719,6 +4727,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 'view_file',
                                 'view_knowledge_file',
                                 'query_knowledge_files',
+                                'query_attached_files',
                             ]
                             and tool_result
                         ):
@@ -4799,13 +4808,8 @@ async def streaming_chat_response_handler(response, ctx):
                         # Restoring to pre-RAG original prevents duplicating
                         # the RAG template across file and tool sources.
                         all_tool_call_sources.extend(tool_call_sources)
-                        native_fc_with_builtins_loop = metadata.get('native_fc_with_builtins', False)
-                        if native_fc_with_builtins_loop:
-                            # Skip per-iteration RAG re-application: initial system
-                            # stays byte-identical, tool results carry their own
-                            # source metadata for citations.
-                            pass
-                        elif all_tool_call_sources and user_message:
+                        skip_rag_reapply = metadata.get('native_fc_with_builtins', False)
+                        if not skip_rag_reapply and all_tool_call_sources and user_message:
                             # Restore pre-RAG message state before re-applying
                             # to prevent RAG template duplication.
                             original_user_message = metadata.get('user_prompt') or user_message

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -972,7 +972,7 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
                 ('resource-type', source_type),
             ])
             roster_parts.append(
-                f'<attached_file{attrs} mode="retrievable">{_ROSTER_HINT}</attached_file>\n'
+                f'<retrievable_file{attrs}>{_ROSTER_HINT}</retrievable_file>\n'
             )
             continue
 
@@ -995,7 +995,7 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
     parts: list[str] = []
     if citeable_parts:
         parts.append('<full_context_files>\n' + ''.join(citeable_parts) + '</full_context_files>\n')
-    parts.append('<available_files>\n' + ''.join(roster_parts) + '</available_files>\n')
+    parts.append('<retrievable_files>\n' + ''.join(roster_parts) + '</retrievable_files>\n')
     return ''.join(parts)
 
 
@@ -2933,18 +2933,22 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
         # Inject builtin tools for native function calling based on enabled features and model capability
         if is_native_fc and builtin_tools_enabled:
-            # add_file_context injects <attached_files> URL refs into user
-            # messages — should only run when the file_context capability is
-            # on, to match the rest of the file-context pipeline.
-            # __attached_files__ powers query_attached_files registration in
-            # get_builtin_tools; same gate so a model with file_context=False
-            # can't reach attached file content through the new tool either.
-            if file_context_enabled:
-                chat_id = metadata.get('chat_id')
-                form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
-                attached_files_for_tools = form_data.get('metadata', {}).get('files', []) or []
-            else:
-                attached_files_for_tools = []
+            # add_file_context injects <attached_files> URL refs (multimodal
+            # viewing / download pointers) into user messages. These don't
+            # carry file content — they're URL pointers — so they run
+            # regardless of the file_context capability (which gates textual
+            # file-content injection). Pre-PR behavior preserved.
+            chat_id = metadata.get('chat_id')
+            form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            # __attached_files__ powers query_attached_files registration,
+            # which DOES expose file content — gate on file_context_enabled
+            # so a model with the capability off can't reach attached file
+            # content through the new tool.
+            attached_files_for_tools = (
+                form_data.get('metadata', {}).get('files', []) or []
+                if file_context_enabled
+                else []
+            )
             builtin_tools = await get_builtin_tools(
                 request,
                 {
@@ -3040,7 +3044,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     system_message = get_system_message(form_data['messages'])
     metadata['system_prompt'] = get_content_from_message(system_message) if system_message else None
     metadata['user_prompt'] = get_last_user_message(form_data['messages'])
-    metadata['sources'] = sources[:] if sources else []
+    # Roster-only entries are chat-level inventory, not evidence — exclude
+    # them from metadata['sources'] so pipe functions / outlet filters don't
+    # have to special-case the missing document/metadata fields.
+    metadata['sources'] = [s for s in sources if not s.get('roster_only')] if sources else []
 
     # If context is not empty, insert it into the messages
     if sources and prompt:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -930,18 +930,11 @@ def handle_responses_streaming_event(
 
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
-    Build context string from citation sources.
+    Render sources for the RAG <context> block.
 
-    Regular sources (with document bodies) are rendered as <source id="N">body</source>
-    tags. Roster-only sources (sources flagged with roster_only=True, carrying no
-    document body) are rendered as <attached_file ...> entries inside an
-    <available_files> block. When both kinds are present, citeable sources are
-    grouped under <full_context_files> so the model can distinguish "content it
-    can cite" from "inventory it must query via tools first".
-
-    When include_content is False the document body is suppressed (citation
-    markers only), mirroring the pre-existing behavior used by the native tool
-    call loop.
+    Regular sources -> <source id="N">body</source>. Roster-only sources
+    (roster_only=True, no body) -> <attached_file ...> inside <available_files>.
+    Mixed input groups citeable sources under <full_context_files>.
     """
     if source_ids is None:
         source_ids = {}
@@ -999,19 +992,12 @@ async def apply_source_context_to_messages(
     force_system_message: bool = False,
 ) -> list:
     """
-    Build source context from citation sources and apply to messages.
-    Uses RAG template to format context for model consumption.
+    Render sources via RAG template and inject into messages.
 
-    When include_content is False, emit <source> tags with id/name but no
-    document body — useful when the content is already present elsewhere
-    (e.g. in a tool result message) and only citation markers are needed.
-
-    When force_system_message is True, the rendered RAG template is appended
-    to the system message regardless of the RAG_SYSTEM_CONTEXT env flag. This
-    is used by the native-function-calling file-context path where the
-    <context> block holds a stable inventory (full-context bodies + a roster
-    of retrievable items) that belongs at the start of the prefix so it
-    caches across turns instead of mutating with every new user message.
+    include_content=False emits citation-only <source> tags (content lives
+    elsewhere, e.g. tool results). force_system_message=True overrides
+    RAG_SYSTEM_CONTEXT and pins the template to the system prompt — used by
+    native FC mode to keep file context in a cache-stable prefix.
     """
     if not sources or not user_message:
         return messages
@@ -1984,23 +1970,12 @@ async def chat_completion_files_handler(
     native_function_calling_with_builtins: bool = False,
 ) -> tuple[dict, dict[str, list]]:
     """
-    Build the file-context sources for the chat completion.
+    Resolve body.metadata.files into sources for the RAG template.
 
-    In the default (prompt-based FC) mode the behavior is unchanged: every
-    item in body.metadata.files is processed through get_sources_from_items
-    (chunked retrieval or full-content depending on item.context and the
-    RAG_FULL_CONTEXT admin flag), and the returned sources are later rendered
-    into the {{CONTEXT}} block of the RAG template.
-
-    When native_function_calling_with_builtins is True, items are partitioned
-    so that chunked-retrieval files/collections (item.context != 'full' and
-    type in {'file', 'collection'}) skip retrieval entirely and instead
-    produce a roster-only source entry that get_source_context renders as an
-    <attached_file ...> tag. The model is expected to call the
-    query_attached_files builtin tool on demand for those items. Full-context
-    items (and natively-full types like text/note/chat/url) still go through
-    get_sources_from_items so their bodies land in the stable system-prompt
-    <full_context_files> block.
+    Default mode: every item runs through get_sources_from_items (unchanged).
+    Native FC mode: chunked file/collection items skip retrieval and become
+    roster-only entries; the model fetches them via query_attached_files.
+    Full-context items still retrieve normally.
     """
     __event_emitter__ = extra_params['__event_emitter__']
     sources = []
@@ -2106,9 +2081,7 @@ async def chat_completion_files_handler(
             except Exception as e:
                 log.exception(e)
 
-        # Append roster-only entries for retrievable items so they appear in
-        # the system-prompt <available_files> block without triggering
-        # retrieval. The model resolves them through query_attached_files.
+        # Roster entries for the <available_files> block (no retrieval).
         for item in retrievable_items:
             sources.append(
                 {
@@ -2968,15 +2941,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
 
-    # In native function calling mode with builtin tools enabled, we route
-    # chunked-retrieval items through the query_attached_files tool so each
-    # retrieval becomes an immutable tool_call/tool_result pair in chat
-    # history (cache-stable across turns). The file-context handler emits
-    # roster-only entries for those items and the RAG template is forced into
-    # the system message so the stable inventory stays in the prefix.
-    # Requires the not-payload_tools branch to have run (otherwise builtin
-    # tools — including query_attached_files — were never registered and
-    # the roster would point at a tool the model cannot call).
+    # Native FC + builtin tools: route chunked retrieval through
+    # query_attached_files (immutable tool results = cache-stable). Gated on
+    # `not payload_tools` because that branch is where builtin tools get
+    # registered — without it the roster would point at a tool that doesn't
+    # exist in the model's tool list.
     model_capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
     native_fc_with_builtins = (
         not payload_tools
@@ -2984,9 +2953,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         and model_capabilities.get('builtin_tools', True)
         and file_context_enabled
     )
-    # Stash for the tool-call loop in streaming_chat_response_handler so it
-    # can skip the per-iteration RAG re-application that would otherwise
-    # mutate the system prompt every time a tool result is appended.
+    # Read by the tool-call loop to skip per-iteration RAG re-application.
     metadata['native_fc_with_builtins'] = native_fc_with_builtins
 
     if file_context_enabled:
@@ -4834,20 +4801,9 @@ async def streaming_chat_response_handler(response, ctx):
                         all_tool_call_sources.extend(tool_call_sources)
                         native_fc_with_builtins_loop = metadata.get('native_fc_with_builtins', False)
                         if native_fc_with_builtins_loop:
-                            # Native FC + builtin tools path. The initial RAG
-                            # template (with <full_context_files> bodies and
-                            # the <available_files> roster) was placed in the
-                            # system prompt at process_chat_payload time and
-                            # must stay there byte-identical for the rest of
-                            # the turn so subsequent tool-loop iterations
-                            # cache-hit the entire prefix. Tool results carry
-                            # their own source/filename metadata in their
-                            # content, so the model can cite from them
-                            # directly without us appending empty
-                            # <source id="N"/> citation markers per
-                            # iteration. Skip restoration + re-application
-                            # entirely; the user-facing source list is still
-                            # streamed via events.
+                            # Skip per-iteration RAG re-application: initial system
+                            # stays byte-identical, tool results carry their own
+                            # source metadata for citations.
                             pass
                         elif all_tool_call_sources and user_message:
                             # Restore pre-RAG message state before re-applying

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2014,8 +2014,18 @@ async def chat_completion_files_handler(
             )
 
         if should_partition:
-            retrievable_items = [item for item in files if is_retrievable(item)]
-            full_context_items = [item for item in files if not is_retrievable(item)]
+            # Sort by id so the rendered <available_files> / <full_context_files>
+            # blocks are byte-identical across turns regardless of how the
+            # frontend ordered metadata.files. Also stabilizes the source_ids
+            # numbering in get_source_context so [N] citations don't drift.
+            retrievable_items = sorted(
+                (item for item in files if is_retrievable(item)),
+                key=lambda item: item.get('id') or '',
+            )
+            full_context_items = sorted(
+                (item for item in files if not is_retrievable(item)),
+                key=lambda item: item.get('id') or '',
+            )
         else:
             retrievable_items = []
             full_context_items = list(files)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2015,10 +2015,8 @@ async def chat_completion_files_handler(
             )
 
         if should_partition:
-            # Sort by id so the rendered <retrievable_files> / <full_context_files>
-            # blocks are byte-identical across turns regardless of how the
-            # frontend ordered metadata.files. Also stabilizes the source_ids
-            # numbering in get_source_context so [N] citations don't drift.
+            # Sort by id so the rendered blocks (and source_ids numbering) stay
+            # byte-stable across turns regardless of frontend file ordering.
             retrievable_items = sorted(
                 (item for item in files if is_retrievable(item)),
                 key=lambda item: item.get('id') or '',
@@ -2109,9 +2107,7 @@ async def chat_completion_files_handler(
                 log.exception(e)
 
         # Roster entries for the <retrievable_files> block (no retrieval).
-        # Both downstream consumers (get_source_context, the unique_ids
-        # counter below) short-circuit on roster_only before touching
-        # document/metadata, and the frontend uses `source.document ?? []`.
+        # Consumers short-circuit on roster_only before touching document/metadata.
         for item in retrievable_items:
             sources.append(
                 {
@@ -2798,10 +2794,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     builtin_tools_enabled = capabilities.get('builtin_tools', True)
     file_context_enabled = capabilities.get('file_context', True)
     is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'
-    # Per-category builtin toggle. query_attached_files lives in the knowledge
-    # category (mirroring query_knowledge_files); if the admin disables that
-    # category, the tool isn't registered, so the new native-FC path must
-    # also revert — otherwise the roster would point at a missing tool.
+    # query_attached_files lives in the knowledge builtin category; if it's
+    # disabled the tool isn't registered, so the native-FC path must revert too.
     knowledge_builtins_enabled = (
         model.get('info', {}).get('meta', {}).get('builtinTools', {}).get('knowledge', True)
     )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -932,8 +932,17 @@ _ROSTER_HINT = 'Use query_attached_files with this id to inspect or search this 
 
 
 def _format_tag_attrs(pairs: list[tuple[str, str | None]]) -> str:
-    """Render space-prefixed XML attributes, skipping any with falsy values."""
-    return ''.join(f' {key}="{value}"' for key, value in pairs if value)
+    """Render space-prefixed XML attributes, skipping any with falsy values.
+
+    Values are HTML-escaped so user-controlled fields (filenames, KB names,
+    arbitrary metadata) can't break out of the attribute and inject sibling
+    tags into the rendered context.
+    """
+    return ''.join(
+        f' {key}="{html.escape(str(value), quote=True)}"'
+        for key, value in pairs
+        if value
+    )
 
 
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
@@ -2778,6 +2787,13 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     builtin_tools_enabled = capabilities.get('builtin_tools', True)
     file_context_enabled = capabilities.get('file_context', True)
     is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'
+    # Per-category builtin toggle. query_attached_files lives in the knowledge
+    # category (mirroring query_knowledge_files); if the admin disables that
+    # category, the tool isn't registered, so the new native-FC path must
+    # also revert — otherwise the roster would point at a missing tool.
+    knowledge_builtins_enabled = (
+        model.get('info', {}).get('meta', {}).get('builtinTools', {}).get('knowledge', True)
+    )
 
     if not payload_tools:
         # Server side tools
@@ -2907,9 +2923,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
         # Inject builtin tools for native function calling based on enabled features and model capability
         if is_native_fc and builtin_tools_enabled:
-            # Add file context to user messages
-            chat_id = metadata.get('chat_id')
-            form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            # add_file_context injects <attached_files> URL refs into user
+            # messages — should only run when the file_context capability is
+            # on, to match the rest of the file-context pipeline.
+            if file_context_enabled:
+                chat_id = metadata.get('chat_id')
+                form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
             builtin_tools = await get_builtin_tools(
                 request,
                 {
@@ -2965,6 +2984,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         not payload_tools
         and is_native_fc
         and builtin_tools_enabled
+        and knowledge_builtins_enabled
         and file_context_enabled
         and not force_full_context
     )
@@ -3002,11 +3022,14 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             force_system_message=native_fc_with_builtins,
         )
 
-    # If there are citations, add them to the data_items
+    # If there are citations, add them to the data_items. Roster-only entries
+    # are chat-level inventory, not evidence the model cited — exclude them so
+    # the frontend citation panel doesn't display empty-content pseudo-sources.
     sources = [
         source
         for source in sources
-        if source.get('source', {}).get('name', '') or source.get('source', {}).get('id', '')
+        if not source.get('roster_only')
+        and (source.get('source', {}).get('name', '') or source.get('source', {}).get('id', ''))
     ]
 
     if len(sources) > 0:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -931,6 +931,11 @@ def handle_responses_streaming_event(
 _ROSTER_HINT = 'Use query_attached_files with this id to inspect or search this item.'
 
 
+def _format_tag_attrs(pairs: list[tuple[str, str | None]]) -> str:
+    """Render space-prefixed XML attributes, skipping any with falsy values."""
+    return ''.join(f' {key}="{value}"' for key, value in pairs if value)
+
+
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
     Render sources for the RAG <context> block.
@@ -952,14 +957,13 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
         source_resource_id = source_info.get('id')
 
         if source.get('roster_only'):
+            attrs = _format_tag_attrs([
+                ('id', source_resource_id),
+                ('name', source_name),
+                ('resource-type', source_type),
+            ])
             roster_parts.append(
-                '<attached_file'
-                + (f' id="{source_resource_id}"' if source_resource_id else '')
-                + (f' name="{source_name}"' if source_name else '')
-                + (f' resource-type="{source_type}"' if source_type else '')
-                + ' mode="retrievable">'
-                + _ROSTER_HINT
-                + '</attached_file>\n'
+                f'<attached_file{attrs} mode="retrievable">{_ROSTER_HINT}</attached_file>\n'
             )
             continue
 
@@ -967,14 +971,14 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
             source_id = (chunk_meta or {}).get('source') or source_resource_id or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
+            attrs = _format_tag_attrs([
+                ('id', str(source_ids[source_id])),
+                ('name', source_name),
+                ('resource-type', source_type),
+                ('resource-id', source_resource_id),
+            ])
             body = document_chunk if include_content else ''
-            citeable_parts.append(
-                f'<source id="{source_ids[source_id]}"'
-                + (f' name="{source_name}"' if source_name else '')
-                + (f' resource-type="{source_type}"' if source_type else '')
-                + (f' resource-id="{source_resource_id}"' if source_resource_id else '')
-                + f'>{body}</source>\n'
-            )
+            citeable_parts.append(f'<source{attrs}>{body}</source>\n')
 
     if not roster_parts:
         return ''.join(citeable_parts)
@@ -1988,32 +1992,27 @@ async def chat_completion_files_handler(
             request.app.state.config.RAG_FULL_CONTEXT
             or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
         )
-        all_full_context = all(item.get('context') == 'full' for item in files)
+        # Only chunked file / collection items get diverted to the roster;
+        # everything else (full-context items, natively-full types, unknown
+        # types) stays in the retrieval pipeline.
+        RETRIEVABLE_TYPES = {'file', 'collection'}
+        should_partition = native_function_calling_with_builtins and not force_full_context
 
-        if native_function_calling_with_builtins and not force_full_context:
-            # Partition once: chunked file/collection -> roster (model uses
-            # query_attached_files); everything else (full-context items,
-            # natively-full types, unknown types) -> retrieval pipeline.
-            FULL_CONTENT_TYPES = {'text', 'note', 'chat', 'url'}
-            RETRIEVABLE_TYPES = {'file', 'collection'}
-            full_context_items, retrievable_items = [], []
-            for item in files:
-                if item.get('context') == 'full' or item.get('type') in FULL_CONTENT_TYPES:
-                    full_context_items.append(item)
-                elif item.get('type') in RETRIEVABLE_TYPES:
-                    retrievable_items.append(item)
-                else:
-                    # Unknown type: route through retrieval to preserve
-                    # whatever shape get_sources_from_items returns today.
-                    full_context_items.append(item)
+        def is_retrievable(item):
+            return (
+                item.get('context') != 'full'
+                and item.get('type') in RETRIEVABLE_TYPES
+            )
+
+        if should_partition:
+            retrievable_items = [item for item in files if is_retrievable(item)]
+            full_context_items = [item for item in files if not is_retrievable(item)]
         else:
-            full_context_items = files
             retrievable_items = []
+            full_context_items = list(files)
 
-        retrieval_all_full_context = (
-            all_full_context
-            if not native_function_calling_with_builtins
-            else all(item.get('context') == 'full' for item in full_context_items)
+        retrieval_all_full_context = all(
+            item.get('context') == 'full' for item in full_context_items
         )
 
         queries = []
@@ -2090,6 +2089,9 @@ async def chat_completion_files_handler(
                 log.exception(e)
 
         # Roster entries for the <available_files> block (no retrieval).
+        # Both downstream consumers (get_source_context, the unique_ids
+        # counter below) short-circuit on roster_only before touching
+        # document/metadata, and the frontend uses `source.document ?? []`.
         for item in retrievable_items:
             sources.append(
                 {
@@ -2098,8 +2100,6 @@ async def chat_completion_files_handler(
                         'id': item.get('id'),
                         'name': item.get('name'),
                     },
-                    'document': [],
-                    'metadata': [],
                     'roster_only': True,
                 }
             )
@@ -2774,6 +2774,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # When the caller provides an explicit OpenAI-style `tools` array in the
     # request body, skip all server-side tool resolution and pass the caller's
     # tools through to the model unchanged.
+    capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
+    builtin_tools_enabled = capabilities.get('builtin_tools', True)
+    file_context_enabled = capabilities.get('file_context', True)
+    is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'
+
     if not payload_tools:
         # Server side tools
         tool_ids = metadata.get('tool_ids', None)
@@ -2901,11 +2906,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             metadata['mcp_clients'] = mcp_clients
 
         # Inject builtin tools for native function calling based on enabled features and model capability
-        # Check if builtin_tools capability is enabled for this model (defaults to True if not specified)
-        builtin_tools_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
-            'builtin_tools', True
-        )
-        if metadata.get('params', {}).get('function_calling') == 'native' and builtin_tools_enabled:
+        if is_native_fc and builtin_tools_enabled:
             # Add file context to user messages
             chat_id = metadata.get('chat_id')
             form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
@@ -2929,7 +2930,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             # (e.g. pipe functions) can access all tools including MCP and builtins.
             metadata['tools'] = tools_dict
 
-            if metadata.get('params', {}).get('function_calling') == 'native':
+            if is_native_fc:
                 # If the function calling is native, then call the tools function calling handler
                 form_data['tools'] = [
                     {'type': 'function', 'function': tool.get('spec', {})} for tool in tools_dict.values()
@@ -2946,14 +2947,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 except Exception as e:
                     log.exception(e)
 
-    # Check if file context extraction is enabled for this model (default True)
-    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
-
     # When the admin globally forces full content (RAG_FULL_CONTEXT or
     # BYPASS_EMBEDDING_AND_RETRIEVAL), there's no chunked retrieval and no
     # partition to do — preserve pre-PR behavior across the board (placement,
     # tool-loop re-application).
-    force_full_context_outer = (
+    force_full_context = (
         request.app.state.config.RAG_FULL_CONTEXT
         or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
     )
@@ -2963,13 +2961,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # `not payload_tools` because that branch is where builtin tools get
     # registered — without it the roster would point at a tool that doesn't
     # exist in the model's tool list.
-    model_capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
     native_fc_with_builtins = (
         not payload_tools
-        and metadata.get('params', {}).get('function_calling') == 'native'
-        and model_capabilities.get('builtin_tools', True)
+        and is_native_fc
+        and builtin_tools_enabled
         and file_context_enabled
-        and not force_full_context_outer
+        and not force_full_context
     )
     # Read by the tool-call loop to skip per-iteration RAG re-application.
     metadata['native_fc_with_builtins'] = native_fc_with_builtins

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -930,28 +930,64 @@ def handle_responses_streaming_event(
 
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
-    Build <source> tag context string from citation sources.
+    Build context string from citation sources.
+
+    Regular sources (with document bodies) are rendered as <source id="N">body</source>
+    tags. Roster-only sources (sources flagged with roster_only=True, carrying no
+    document body) are rendered as <attached_file ...> entries inside an
+    <available_files> block. When both kinds are present, citeable sources are
+    grouped under <full_context_files> so the model can distinguish "content it
+    can cite" from "inventory it must query via tools first".
+
+    When include_content is False the document body is suppressed (citation
+    markers only), mirroring the pre-existing behavior used by the native tool
+    call loop.
     """
-    context_string = ''
     if source_ids is None:
         source_ids = {}
+
+    citeable_parts: list[str] = []
+    roster_parts: list[str] = []
+
     for source in sources:
+        src_meta = source.get('source') or {}
+        src_name = src_meta.get('name')
+        src_type = src_meta.get('type')
+        src_rid = src_meta.get('id')
+
+        if source.get('roster_only'):
+            roster_parts.append(
+                '<attached_file'
+                + (f' id="{src_rid}"' if src_rid else '')
+                + (f' name="{src_name}"' if src_name else '')
+                + (f' resource-type="{src_type}"' if src_type else '')
+                + ' mode="retrievable">'
+                + 'Use query_attached_files with this id to inspect or search this item.'
+                + '</attached_file>\n'
+            )
+            continue
+
         for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
+            source_id = (meta or {}).get('source') or src_rid or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
-            src_name = source.get('source', {}).get('name')
-            src_type = source.get('source', {}).get('type')
-            src_rid = source.get('source', {}).get('id')
             body = doc if include_content else ''
-            context_string += (
+            citeable_parts.append(
                 f'<source id="{source_ids[source_id]}"'
                 + (f' name="{src_name}"' if src_name else '')
                 + (f' resource-type="{src_type}"' if src_type else '')
                 + (f' resource-id="{src_rid}"' if src_rid else '')
                 + f'>{body}</source>\n'
             )
-    return context_string
+
+    if not roster_parts:
+        return ''.join(citeable_parts)
+
+    parts: list[str] = []
+    if citeable_parts:
+        parts.append('<full_context_files>\n' + ''.join(citeable_parts) + '</full_context_files>\n')
+    parts.append('<available_files>\n' + ''.join(roster_parts) + '</available_files>\n')
+    return ''.join(parts)
 
 
 async def apply_source_context_to_messages(
@@ -960,6 +996,7 @@ async def apply_source_context_to_messages(
     sources: list,
     user_message: str,
     include_content: bool = True,
+    force_system_message: bool = False,
 ) -> list:
     """
     Build source context from citation sources and apply to messages.
@@ -968,6 +1005,13 @@ async def apply_source_context_to_messages(
     When include_content is False, emit <source> tags with id/name but no
     document body — useful when the content is already present elsewhere
     (e.g. in a tool result message) and only citation markers are needed.
+
+    When force_system_message is True, the rendered RAG template is appended
+    to the system message regardless of the RAG_SYSTEM_CONTEXT env flag. This
+    is used by the native-function-calling file-context path where the
+    <context> block holds a stable inventory (full-context bodies + a roster
+    of retrievable items) that belongs at the start of the prefix so it
+    caches across turns instead of mutating with every new user message.
     """
     if not sources or not user_message:
         return messages
@@ -978,7 +1022,7 @@ async def apply_source_context_to_messages(
     if not context:
         return messages
 
-    if RAG_SYSTEM_CONTEXT:
+    if RAG_SYSTEM_CONTEXT or force_system_message:
         return add_or_update_system_message(
             await rag_template(request.app.state.config.RAG_TEMPLATE, context, user_message),
             messages,
@@ -1933,17 +1977,66 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
 
 
 async def chat_completion_files_handler(
-    request: Request, body: dict, extra_params: dict, user: UserModel
+    request: Request,
+    body: dict,
+    extra_params: dict,
+    user: UserModel,
+    native_function_calling_with_builtins: bool = False,
 ) -> tuple[dict, dict[str, list]]:
+    """
+    Build the file-context sources for the chat completion.
+
+    In the default (prompt-based FC) mode the behavior is unchanged: every
+    item in body.metadata.files is processed through get_sources_from_items
+    (chunked retrieval or full-content depending on item.context and the
+    RAG_FULL_CONTEXT admin flag), and the returned sources are later rendered
+    into the {{CONTEXT}} block of the RAG template.
+
+    When native_function_calling_with_builtins is True, items are partitioned
+    so that chunked-retrieval files/collections (item.context != 'full' and
+    type in {'file', 'collection'}) skip retrieval entirely and instead
+    produce a roster-only source entry that get_source_context renders as an
+    <attached_file ...> tag. The model is expected to call the
+    query_attached_files builtin tool on demand for those items. Full-context
+    items (and natively-full types like text/note/chat/url) still go through
+    get_sources_from_items so their bodies land in the stable system-prompt
+    <full_context_files> block.
+    """
     __event_emitter__ = extra_params['__event_emitter__']
     sources = []
 
     if files := body.get('metadata', {}).get('files', None):
-        # Check if all files are in full context mode
+        force_full_context = request.app.state.config.RAG_FULL_CONTEXT
         all_full_context = all(item.get('context') == 'full' for item in files)
 
+        if native_function_calling_with_builtins and not force_full_context:
+            # Partition: full-context items + natively-full types -> retrieval;
+            # everything else -> roster-only (model queries via tool on demand).
+            FULL_CONTENT_TYPES = {'text', 'note', 'chat', 'url'}
+            full_context_items = [
+                item
+                for item in files
+                if item.get('context') == 'full' or item.get('type') in FULL_CONTENT_TYPES
+            ]
+            retrievable_items = [
+                item
+                for item in files
+                if item not in full_context_items and item.get('type') in {'file', 'collection'}
+            ]
+        else:
+            full_context_items = files
+            retrievable_items = []
+
+        retrieval_all_full_context = (
+            all_full_context
+            if not native_function_calling_with_builtins
+            else all(item.get('context') == 'full' for item in full_context_items)
+        )
+
         queries = []
-        if not all_full_context:
+        needs_query_generation = bool(full_context_items) and not retrieval_all_full_context
+
+        if needs_query_generation:
             try:
                 queries_response = await generate_queries(
                     request,
@@ -1987,36 +2080,60 @@ async def chat_completion_files_handler(
         if len(queries) == 0:
             queries = [get_last_user_message(body['messages']) or '']
 
-        try:
-            # Directly await async get_sources_from_items (no thread needed - fully async now)
-            sources = await get_sources_from_items(
-                request=request,
-                items=files,
-                queries=queries,
-                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
-                    query, prefix=prefix, user=user
-                ),
-                k=request.app.state.config.TOP_K,
-                reranking_function=(
-                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
-                    if request.app.state.RERANKING_FUNCTION
-                    else None
-                ),
-                k_reranker=request.app.state.config.TOP_K_RERANKER,
-                r=request.app.state.config.RELEVANCE_THRESHOLD,
-                hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
-                hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
-                full_context=all_full_context or request.app.state.config.RAG_FULL_CONTEXT,
-                user=user,
+        if full_context_items:
+            try:
+                # Directly await async get_sources_from_items (no thread needed - fully async now)
+                sources = await get_sources_from_items(
+                    request=request,
+                    items=full_context_items,
+                    queries=queries,
+                    embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                        query, prefix=prefix, user=user
+                    ),
+                    k=request.app.state.config.TOP_K,
+                    reranking_function=(
+                        (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                        if request.app.state.RERANKING_FUNCTION
+                        else None
+                    ),
+                    k_reranker=request.app.state.config.TOP_K_RERANKER,
+                    r=request.app.state.config.RELEVANCE_THRESHOLD,
+                    hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
+                    hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
+                    full_context=retrieval_all_full_context or force_full_context,
+                    user=user,
+                )
+            except Exception as e:
+                log.exception(e)
+
+        # Append roster-only entries for retrievable items so they appear in
+        # the system-prompt <available_files> block without triggering
+        # retrieval. The model resolves them through query_attached_files.
+        for item in retrievable_items:
+            sources.append(
+                {
+                    'source': {
+                        'type': item.get('type'),
+                        'id': item.get('id'),
+                        'name': item.get('name'),
+                    },
+                    'document': [],
+                    'metadata': [],
+                    'roster_only': True,
+                }
             )
-        except Exception as e:
-            log.exception(e)
 
         log.debug(f'rag_contexts:sources: {sources}')
 
         unique_ids = set()
         for source in sources or []:
             if not source or len(source.keys()) == 0:
+                continue
+
+            if source.get('roster_only'):
+                _id = (source.get('source') or {}).get('id')
+                if _id:
+                    unique_ids.add(_id)
                 continue
 
             documents = source.get('document') or []
@@ -2817,6 +2934,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     **extra_params,
                     '__event_emitter__': event_emitter,
                     '__skill_ids__': [s.id for s in available_skills if s.id not in user_skill_ids],
+                    '__attached_files__': form_data.get('metadata', {}).get('files', []) or [],
                 },
                 features,
                 model,
@@ -2850,9 +2968,36 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
 
+    # In native function calling mode with builtin tools enabled, we route
+    # chunked-retrieval items through the query_attached_files tool so each
+    # retrieval becomes an immutable tool_call/tool_result pair in chat
+    # history (cache-stable across turns). The file-context handler emits
+    # roster-only entries for those items and the RAG template is forced into
+    # the system message so the stable inventory stays in the prefix.
+    # Requires the not-payload_tools branch to have run (otherwise builtin
+    # tools — including query_attached_files — were never registered and
+    # the roster would point at a tool the model cannot call).
+    model_capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
+    native_fc_with_builtins = (
+        not payload_tools
+        and metadata.get('params', {}).get('function_calling') == 'native'
+        and model_capabilities.get('builtin_tools', True)
+        and file_context_enabled
+    )
+    # Stash for the tool-call loop in streaming_chat_response_handler so it
+    # can skip the per-iteration RAG re-application that would otherwise
+    # mutate the system prompt every time a tool result is appended.
+    metadata['native_fc_with_builtins'] = native_fc_with_builtins
+
     if file_context_enabled:
         try:
-            form_data, flags = await chat_completion_files_handler(request, form_data, extra_params, user)
+            form_data, flags = await chat_completion_files_handler(
+                request,
+                form_data,
+                extra_params,
+                user,
+                native_function_calling_with_builtins=native_fc_with_builtins,
+            )
             sources.extend(flags.get('sources', []))
         except Exception as e:
             log.exception(e)
@@ -2867,7 +3012,13 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     # If context is not empty, insert it into the messages
     if sources and prompt:
-        form_data['messages'] = await apply_source_context_to_messages(request, form_data['messages'], sources, prompt)
+        form_data['messages'] = await apply_source_context_to_messages(
+            request,
+            form_data['messages'],
+            sources,
+            prompt,
+            force_system_message=native_fc_with_builtins,
+        )
 
     # If there are citations, add them to the data_items
     sources = [
@@ -4681,7 +4832,24 @@ async def streaming_chat_response_handler(response, ctx):
                         # Restoring to pre-RAG original prevents duplicating
                         # the RAG template across file and tool sources.
                         all_tool_call_sources.extend(tool_call_sources)
-                        if all_tool_call_sources and user_message:
+                        native_fc_with_builtins_loop = metadata.get('native_fc_with_builtins', False)
+                        if native_fc_with_builtins_loop:
+                            # Native FC + builtin tools path. The initial RAG
+                            # template (with <full_context_files> bodies and
+                            # the <available_files> roster) was placed in the
+                            # system prompt at process_chat_payload time and
+                            # must stay there byte-identical for the rest of
+                            # the turn so subsequent tool-loop iterations
+                            # cache-hit the entire prefix. Tool results carry
+                            # their own source/filename metadata in their
+                            # content, so the model can cite from them
+                            # directly without us appending empty
+                            # <source id="N"/> citation markers per
+                            # iteration. Skip restoration + re-application
+                            # entirely; the user-facing source list is still
+                            # streamed via events.
+                            pass
+                        elif all_tool_call_sources and user_message:
                             # Restore pre-RAG message state before re-applying
                             # to prevent RAG template duplication.
                             original_user_message = metadata.get('user_prompt') or user_message

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2949,6 +2949,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
 
+    # When the admin globally forces full content (RAG_FULL_CONTEXT or
+    # BYPASS_EMBEDDING_AND_RETRIEVAL), there's no chunked retrieval and no
+    # partition to do — preserve pre-PR behavior across the board (placement,
+    # tool-loop re-application).
+    force_full_context_outer = (
+        request.app.state.config.RAG_FULL_CONTEXT
+        or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+    )
+
     # Native FC + builtin tools: route chunked retrieval through
     # query_attached_files (immutable tool results = cache-stable). Gated on
     # `not payload_tools` because that branch is where builtin tools get
@@ -2960,6 +2969,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         and metadata.get('params', {}).get('function_calling') == 'native'
         and model_capabilities.get('builtin_tools', True)
         and file_context_enabled
+        and not force_full_context_outer
     )
     # Read by the tool-call loop to skip per-iteration RAG re-application.
     metadata['native_fc_with_builtins'] = native_fc_with_builtins

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -949,9 +949,10 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
     """
     Render sources for the RAG <context> block.
 
-    Regular sources -> <source id="N">body</source>. Roster-only sources
-    (roster_only=True, no body) -> <attached_file ...> inside <available_files>.
-    Mixed input groups citeable sources under <full_context_files>.
+    Citeable sources -> <source id="N">body</source>. Roster-only sources
+    (roster_only=True, no body) -> <retrievable_file ...> inside <retrievable_files>.
+    Citeable-only input stays bare (no wrapper, backward compatible); mixed
+    input wraps citeable sources under <full_context_files>.
     """
     if source_ids is None:
         source_ids = {}
@@ -2014,7 +2015,7 @@ async def chat_completion_files_handler(
             )
 
         if should_partition:
-            # Sort by id so the rendered <available_files> / <full_context_files>
+            # Sort by id so the rendered <retrievable_files> / <full_context_files>
             # blocks are byte-identical across turns regardless of how the
             # frontend ordered metadata.files. Also stabilizes the source_ids
             # numbering in get_source_context so [N] citations don't drift.
@@ -2107,7 +2108,7 @@ async def chat_completion_files_handler(
             except Exception as e:
                 log.exception(e)
 
-        # Roster entries for the <available_files> block (no retrieval).
+        # Roster entries for the <retrievable_files> block (no retrieval).
         # Both downstream consumers (get_source_context, the unique_ids
         # counter below) short-circuit on roster_only before touching
         # document/metadata, and the frontend uses `source.document ?? []`.
@@ -2933,17 +2934,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
         # Inject builtin tools for native function calling based on enabled features and model capability
         if is_native_fc and builtin_tools_enabled:
-            # add_file_context injects <attached_files> URL refs (multimodal
-            # viewing / download pointers) into user messages. These don't
-            # carry file content — they're URL pointers — so they run
-            # regardless of the file_context capability (which gates textual
-            # file-content injection). Pre-PR behavior preserved.
+            # add_file_context injects URL pointers (not content), so it runs
+            # regardless of the file_context capability — pre-PR behavior.
             chat_id = metadata.get('chat_id')
             form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
-            # __attached_files__ powers query_attached_files registration,
-            # which DOES expose file content — gate on file_context_enabled
-            # so a model with the capability off can't reach attached file
-            # content through the new tool.
+            # query_attached_files exposes content, so gate its input list on
+            # the file_context capability.
             attached_files_for_tools = (
                 form_data.get('metadata', {}).get('files', []) or []
                 if file_context_enabled
@@ -2986,21 +2982,16 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 except Exception as e:
                     log.exception(e)
 
-    # When the admin globally forces full content (RAG_FULL_CONTEXT or
-    # BYPASS_EMBEDDING_AND_RETRIEVAL), there's no chunked retrieval and no
-    # partition to do — preserve pre-PR behavior across the board (placement,
-    # tool-loop re-application).
+    # Admin-forced full content (either flag) means no chunked retrieval to
+    # partition — keep pre-PR behavior.
     force_full_context = (
         request.app.state.config.RAG_FULL_CONTEXT
         or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
     )
 
-    # The new path is only meaningful when there's at least one chunked
-    # file/collection to route through query_attached_files. Without it,
-    # forcing system-prompt placement and skipping the tool-loop RAG
-    # re-application would regress citation handling for unrelated native
-    # tool calls (search_web, query_knowledge_files, view_file, etc.) in
-    # no-file or full-context-only chats.
+    # Only activate when there's a chunked file/collection to route through
+    # the tool; otherwise the gate would needlessly regress citation handling
+    # for unrelated native tool calls in no-file / full-context-only chats.
     attached_files_list = (form_data.get('metadata') or {}).get('files') or []
     has_retrievable_attached_files = any(
         item.get('context') != 'full'
@@ -3008,11 +2999,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         for item in attached_files_list
     )
 
-    # Native FC + builtin tools: route chunked retrieval through
-    # query_attached_files (immutable tool results = cache-stable). Gated on
-    # `not payload_tools` because that branch is where builtin tools get
-    # registered — without it the roster would point at a tool that doesn't
-    # exist in the model's tool list.
+    # `not payload_tools` because builtin tools (incl. query_attached_files)
+    # only get registered in that branch — otherwise the roster would point
+    # at a tool the model doesn't have.
     native_fc_with_builtins = (
         not payload_tools
         and is_native_fc

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -253,6 +253,21 @@ def replace_messages_variable(template: str, messages: Optional[list[dict]] = No
 # {{prompt:middletruncate:8000}}
 
 
+def warn_if_deprecated_rag_template_placeholders(template: str | None) -> None:
+    """Warn (at config-load time) if a RAG template uses removed placeholders.
+
+    Call this where RAG_TEMPLATE is set — startup and the admin update
+    endpoint — rather than per-request, to avoid log spam.
+    """
+    if template and ('{{QUERY}}' in template or '[query]' in template):
+        log.warning(
+            "RAG_TEMPLATE contains {{QUERY}}/[query] placeholders, which are "
+            "no longer substituted (the user's message is already in the "
+            'messages array) and will be stripped to empty. Remove them from '
+            'your template.'
+        )
+
+
 # Let the context given here not distort the question,
 # but illuminate it, so that the answer serves the one who asked.
 async def rag_template(template: str, context: str, query: str):
@@ -277,14 +292,6 @@ async def rag_template(template: str, context: str, query: str):
             'WARNING: Potential prompt injection attack: the RAG '
             "context contains '<context>' and '</context>'. This might be "
             'nothing, or the user might be trying to hack something.'
-        )
-
-    if '{{QUERY}}' in template or '[query]' in template:
-        log.warning(
-            "rag_template: {{QUERY}}/[query] placeholders are no longer "
-            "substituted (the user's message already appears in the "
-            "messages array). Remove them from your RAG_TEMPLATE to silence "
-            "this notice."
         )
 
     # Strip placeholders from the TEMPLATE first, then substitute context.

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import re
-import uuid
 from datetime import datetime
 from typing import Any, Optional
 
@@ -257,6 +256,17 @@ def replace_messages_variable(template: str, messages: Optional[list[dict]] = No
 # Let the context given here not distort the question,
 # but illuminate it, so that the answer serves the one who asked.
 async def rag_template(template: str, context: str, query: str):
+    """
+    Render the RAG template with the provided context.
+
+    The `query` parameter is accepted for backward compatibility but is no
+    longer substituted into the template. The {{QUERY}} / [query]
+    placeholders are removed: the user's message is already present in the
+    messages array, duplicating it inside the rendered template adds no
+    value, and when the template is injected into the system prompt it
+    would mutate every turn and defeat prefix caching. Any remaining
+    placeholders in a custom template are stripped to plain empty strings.
+    """
     if template.strip() == '':
         template = DEFAULT_RAG_TEMPLATE
 
@@ -272,25 +282,20 @@ async def rag_template(template: str, context: str, query: str):
             'nothing, or the user might be trying to hack something.'
         )
 
-    query_placeholders = []
-    if '[query]' in context:
-        query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
-        template = template.replace('[query]', query_placeholder)
-        query_placeholders.append((query_placeholder, '[query]'))
-
-    if '{{QUERY}}' in context:
-        query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
-        template = template.replace('{{QUERY}}', query_placeholder)
-        query_placeholders.append((query_placeholder, '{{QUERY}}'))
+    if '{{QUERY}}' in template or '[query]' in template:
+        log.debug(
+            "rag_template: {{QUERY}}/[query] placeholders are no longer "
+            "substituted (the user's message already appears in the "
+            "messages array). Remove them from your RAG_TEMPLATE to silence "
+            "this notice."
+        )
 
     template = template.replace('[context]', context)
     template = template.replace('{{CONTEXT}}', context)
 
-    template = template.replace('[query]', query)
-    template = template.replace('{{QUERY}}', query)
-
-    for query_placeholder, original_placeholder in query_placeholders:
-        template = template.replace(query_placeholder, original_placeholder)
+    # Strip leftover placeholders so they don't leak into the rendered output.
+    template = template.replace('[query]', '')
+    template = template.replace('{{QUERY}}', '')
 
     return template
 

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -259,13 +259,10 @@ async def rag_template(template: str, context: str, query: str):
     """
     Render the RAG template with the provided context.
 
-    The `query` parameter is accepted for backward compatibility but is no
-    longer substituted into the template. The {{QUERY}} / [query]
-    placeholders are removed: the user's message is already present in the
-    messages array, duplicating it inside the rendered template adds no
-    value, and when the template is injected into the system prompt it
-    would mutate every turn and defeat prefix caching. Any remaining
-    placeholders in a custom template are stripped to plain empty strings.
+    `query` is kept for backward compatibility but no longer substituted:
+    the user's message is already in the messages array, and substituting it
+    here would mutate a system-pinned template every turn and defeat prefix
+    caching. {{QUERY}} / [query] placeholders are stripped to empty.
     """
     if template.strip() == '':
         template = DEFAULT_RAG_TEMPLATE

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -283,19 +283,21 @@ async def rag_template(template: str, context: str, query: str):
         )
 
     if '{{QUERY}}' in template or '[query]' in template:
-        log.debug(
+        log.warning(
             "rag_template: {{QUERY}}/[query] placeholders are no longer "
             "substituted (the user's message already appears in the "
             "messages array). Remove them from your RAG_TEMPLATE to silence "
             "this notice."
         )
 
-    template = template.replace('[context]', context)
-    template = template.replace('{{CONTEXT}}', context)
-
-    # Strip leftover placeholders so they don't leak into the rendered output.
+    # Strip placeholders from the TEMPLATE first, then substitute context.
+    # Order matters: if context were substituted first, any literal [query]
+    # / {{QUERY}} inside a retrieved chunk would also get erased.
     template = template.replace('[query]', '')
     template = template.replace('{{QUERY}}', '')
+
+    template = template.replace('[context]', context)
+    template = template.replace('{{CONTEXT}}', context)
 
     return template
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -65,6 +65,7 @@ from open_webui.tools.builtin import (
     list_knowledge,
     list_knowledge_bases,
     list_memories,
+    query_attached_files,
     query_knowledge_bases,
     query_knowledge_files,
     replace_memory_content,
@@ -469,6 +470,24 @@ async def get_builtin_tools(
     folder_knowledge = extra_params.get('__metadata__', {}).get('folder_knowledge')
     if folder_knowledge:
         model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
+
+    # User-attached files/KBs for the current chat. In native FC mode with
+    # file_context enabled the middleware skips chunked retrieval for these
+    # items and instead emits a roster of <attached_file> entries into the
+    # system prompt; query_attached_files is the model's only path to read
+    # their content, so it must be registered whenever such items exist.
+    # When RAG_FULL_CONTEXT is on globally, every item is force-injected as
+    # full content already, so the retrievable list is empty by definition.
+    attached_files = extra_params.get('__attached_files__') or []
+    force_full_context = getattr(request.app.state.config, 'RAG_FULL_CONTEXT', False)
+    retrievable_attached_files = (
+        []
+        if force_full_context
+        else [
+            item for item in attached_files
+            if item.get('context') != 'full' and item.get('type') in ('file', 'collection')
+        ]
+    )
     if is_builtin_tool_enabled('knowledge'):
         from open_webui.env import ENABLE_KB_EXEC
 
@@ -497,6 +516,13 @@ async def get_builtin_tools(
                 grep_knowledge_files, search_knowledge_files, query_knowledge_files,
                 view_knowledge_file,
             ])
+
+        # Register query_attached_files whenever the chat carries retrievable
+        # user-attached files/KBs. This is independent of model_knowledge —
+        # model-attached knowledge is served by query_knowledge_files, while
+        # user-attached items are scoped to the current chat only.
+        if retrievable_attached_files:
+            builtin_functions.append(query_attached_files)
 
     # Chats tools - search and fetch user's chat history
     if is_builtin_tool_enabled('chats'):
@@ -619,6 +645,7 @@ async def get_builtin_tools(
                 '__chat_id__': extra_params.get('__chat_id__'),
                 '__message_id__': extra_params.get('__message_id__'),
                 '__model_knowledge__': model_knowledge,
+                '__attached_files__': retrievable_attached_files,
             },
         )
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -471,13 +471,9 @@ async def get_builtin_tools(
     if folder_knowledge:
         model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
 
-    # User-attached files/KBs for the current chat. In native FC mode with
-    # file_context enabled the middleware skips chunked retrieval for these
-    # items and instead emits a roster of <attached_file> entries into the
-    # system prompt; query_attached_files is the model's only path to read
-    # their content, so it must be registered whenever such items exist.
-    # When RAG_FULL_CONTEXT is on globally, every item is force-injected as
-    # full content already, so the retrievable list is empty by definition.
+    # Chat-attached items the model can read via query_attached_files.
+    # RAG_FULL_CONTEXT=on injects everything as full content, so nothing is
+    # retrievable in that case.
     attached_files = extra_params.get('__attached_files__') or []
     force_full_context = getattr(request.app.state.config, 'RAG_FULL_CONTEXT', False)
     retrievable_attached_files = (
@@ -517,10 +513,8 @@ async def get_builtin_tools(
                 view_knowledge_file,
             ])
 
-        # Register query_attached_files whenever the chat carries retrievable
-        # user-attached files/KBs. This is independent of model_knowledge —
-        # model-attached knowledge is served by query_knowledge_files, while
-        # user-attached items are scoped to the current chat only.
+        # Chat-scoped retrieval (distinct from query_knowledge_files which
+        # searches model-attached knowledge).
         if retrievable_attached_files:
             builtin_functions.append(query_attached_files)
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -472,10 +472,13 @@ async def get_builtin_tools(
         model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
 
     # Chat-attached items the model can read via query_attached_files.
-    # RAG_FULL_CONTEXT=on injects everything as full content, so nothing is
-    # retrievable in that case.
+    # RAG_FULL_CONTEXT or BYPASS_EMBEDDING_AND_RETRIEVAL force everything to
+    # full content, leaving nothing for chunked retrieval.
     attached_files = extra_params.get('__attached_files__') or []
-    force_full_context = getattr(request.app.state.config, 'RAG_FULL_CONTEXT', False)
+    force_full_context = (
+        request.app.state.config.RAG_FULL_CONTEXT
+        or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+    )
     retrievable_attached_files = (
         []
         if force_full_context


### PR DESCRIPTION
# Cache-optimal file context routing in native function calling mode

Open WebUI's current handling of user-attached files, knowledge bases, notes, and other retrievable items produces near-pathological prompt-cache behavior on every major provider (OpenAI, Anthropic, Google). This PR identifies three distinct cache-destroying scenarios in the existing code, traces each to its root cause, and fixes all three behind a single coordinated change that activates **only** in native function calling mode with builtin tools and file context enabled, and only when the admin hasn't globally forced full content via `RAG_FULL_CONTEXT` or `BYPASS_EMBEDDING_AND_RETRIEVAL`. Default and prompt-based function calling behavior is preserved byte-for-byte.

---

## Background: how the existing file-context pipeline works

When a user attaches a file, a knowledge base, or otherwise references content in the chat, the request body carries those items in `body.metadata.files`. Each item has a `type` (`file`, `collection`, `text`, `note`, `chat`, `url`, legacy collections) and a `context` flag (`'full'` or omitted = chunked retrieval). The pipeline that turns those items into prompt content lives mostly in `backend/open_webui/utils/middleware.py`:

1. **`chat_completion_files_handler`** iterates `body.metadata.files`. For chunked items it generates retrieval queries from the conversation and calls `get_sources_from_items` with the result. For full-context items it bypasses the query generation and pulls the entire content. Either way it returns a flat `sources` list where each source is `{'source': {item dict}, 'document': [chunks or full body], 'metadata': [...]}`.
2. **`apply_source_context_to_messages`** renders those sources into a `<context>…</context>` block via `rag_template(RAG_TEMPLATE, context, user_message)` and inserts the result into the messages — either appended to the system prompt (if `RAG_SYSTEM_CONTEXT=true`) or prepended to the last user message (default).
3. The **tool-call loop** inside `streaming_chat_response_handler` handles models that respond with `tool_calls`. After each tool result it restores the pre-RAG state of system and user messages, then re-applies `rag_template` with the **initial sources plus all accumulated tool-call sources** (the latter rendered with `include_content=False` so only `<source id="N"/>` citation markers are emitted — the actual content already lives in the tool result messages).

This pipeline is fine if you don't care about prompt caching. It is the wrong shape if you do, for three independent reasons described next.

---

## The three cache-destroying scenarios this PR fixes

### Scenario 1 — `RAG_SYSTEM_CONTEXT=false` (default): the second-newest user message mutates every turn

This is the OWUI default. The rendered RAG template is **prepended to the latest user message** via `add_or_update_user_message(content, messages, append=False)`. That helper only touches `messages[-1]`. The persisted chat history stores user messages **without** the RAG prepend — RAG is freshly re-applied on every request from the clean chat state.

Trace a two-turn chat with a file attached:

**Turn 1 sent to provider:**

```
[system]
[user₁ = <context>…retrieved chunks for user₁'s query…</context>\n\noriginal text of user₁]
```

**Turn 2 sent to provider:**

```
[system]
[user₁ = original text of user₁]                                     ← prepend gone
[assistant₁]
[user₂ = <context>…retrieved chunks for user₂'s query…</context>\n\noriginal text of user₂]
```

**The mutation:** `user₁` was sent in turn 1 wrapped in RAG content; in turn 2 it is sent bare. Same message ID, different bytes. Every prefix-based cache (OpenAI, Anthropic with `cache_control`, Gemini) breaks at the point where `user₁` starts diverging. The provider can only cache the prefix up to and including `[system]` — assistant and user messages from any prior turn are wasted.

**With Anthropic specifically:** Open WebUI does not emit any `cache_control: {type: "ephemeral"}` breakpoints anywhere (verified: only `Cache-Control` HTTP headers in `security_headers.py`, unrelated). Anthropic requires explicit markers — without them the API does **not** consult the cache at all. So Anthropic users currently get zero caching regardless of message structure, and on top of that pay full input-token price for the file body on every turn.

**Impact:** files frequently make up the majority of total prompt tokens. Putting them in the volatile region of the prefix means most of the chat's input cost can never be cached. Long chats with attached files pay nearly the full input cost on every turn.

### Scenario 2 — `RAG_SYSTEM_CONTEXT=true` with any chunked retrieval: the system prompt mutates every turn

Setting `RAG_SYSTEM_CONTEXT=true` moves the rendered RAG template into the **system prompt** via `add_or_update_system_message(content, messages, append=True)`. For **full-context** items this is great: file bodies are stable across turns, the system prompt is stable across turns, every provider caches the entire history forever. If the user adds or removes a full-context item, the system prompt mutates for exactly one turn, then stabilizes.

But the same code path is used for **chunked retrieval** items. `chat_completion_files_handler` re-runs the retrieval pipeline on every turn, generating different queries from the new conversation state and pulling different top-k chunks. Those chunks are embedded inside `<context>…</context>` in the system prompt. Different query → different chunks → different system prompt.

**Trace:**

**Turn 1 sent:**

```
[system = original + <context>chunks retrieved for "what is X?"</context>]
[user₁ = "what is X?"]
```

**Turn 2 sent:**

```
[system = original + <context>chunks retrieved for "and what about Y?"</context>]   ← mutated
[user₁]
[assistant₁]
[user₂ = "and what about Y?"]
```

**The mutation:** the system prompt is the very first thing in the prefix. Mutating it invalidates **every** cache breakpoint downstream. For all providers. On every turn.

**Impact:** for any deployment with chunked-retrieval files (the default mode and the most common configuration) and `RAG_SYSTEM_CONTEXT=true`, the chat history cache is effectively never used. The user pays full input cost on every single turn for the entire conversation history, the system prompt, and the chunks.

The user is stuck choosing between Scenario 1 (cache breaks at second-newest user message) and Scenario 2 (cache breaks at system prompt). There is no setting that produces good caching for the common case of chunked retrieval.

### Scenario 3 — the tool-call loop re-renders the RAG template on every iteration

This scenario is independent of `RAG_SYSTEM_CONTEXT` and stacks on top of both Scenarios 1 and 2. It triggers whenever the model produces tool calls.

When a model in native function calling mode responds with `tool_calls`, the existing code runs the following on **every iteration of the tool-call loop**:

1. Restore the user message to its pre-RAG state (`set_last_user_message_content`).
2. Restore the system prompt to its pre-RAG state (`replace_system_message_content`).
3. Rebuild the source context by concatenating `get_source_context(metadata['sources'])` (initial file sources with full content) with `get_source_context(all_tool_call_sources, include_content=False)` (citation markers only for tool sources — `<source id="N"/>` with empty body, because the actual content already lives in the tool result messages).
4. Re-apply `rag_template` to that combined context.
5. Inject the rendered template into the system prompt or last user message depending on `RAG_SYSTEM_CONTEXT`.

The purpose of this re-application is to give the model `<source id="N"/>` citation markers it can use to cite tool-derived content using the `[N]` format dictated by `DEFAULT_RAG_TEMPLATE`. Each new tool call adds one more such marker to the RAG template content.

**Trace a research-style turn where the model fires six tool calls:**

```
user: "go research X and Y for me"

iter 0 (initial request):
  [system = base + <context>initial sources</context>]   (or in user msg if RAG_SYSTEM_CONTEXT=false)
  [user]

iter 1 (after tool call 1):
  [system = base + <context>initial sources + <source id="2"/></context>]   ← mutated
  [user] [tool_call_1] [tool_result_1]

iter 2:
  [system = base + <context>initial sources + <source id="2"/><source id="3"/></context>]   ← mutated again
  [user] [tool_call_1] [tool_result_1] [tool_call_2] [tool_result_2]

iter 3:
  [system = base + <context>initial sources + <source id="2"/><source id="3"/><source id="4"/></context>]
  …
```

**The mutation:** the system prompt (or last user message) carries an ever-growing list of empty `<source id="N"/>` markers, one new one per tool call. Every iteration mutates the prefix at the injection point. Every iteration's cache breaks at that mutation. For long tool-call chains (agentic flows, multi-step research, browse-the-web style tasks), the user pays **full input-token cost on every iteration** for the entire conversation history including all previous tool results — exactly the content that, by being immutable, should have been the easiest to cache.

This is the worst of the three scenarios because:

- It triggers on the workload that benefits most from caching (long tool-call chains accumulate a lot of context).
- It triggers even when the user has set `RAG_SYSTEM_CONTEXT=true` and attached only full-context files (Scenario 2's "happy path") — the tool-loop re-application brings the mutation problem right back.
- The empty `<source id="N"/>` markers add essentially no value: the tool result content already carries source/filename metadata that the model can cite from directly.

---

## What this PR does

The fix is structural and addresses all three scenarios simultaneously, gated to native function calling mode with builtin tools and file context enabled, when the admin has not globally forced full content.

### Decouple the static and dynamic parts of the `<context>` block

`DEFAULT_RAG_TEMPLATE` is left intact in shape (`citation instructions + <context>{{CONTEXT}}</context>`). What changes is **what goes into `{{CONTEXT}}`** and **where the rendered template lands**. The `<context>` block becomes a stable chat-level inventory rather than a per-turn retrieval dump:

```xml
<context>
  <full_context_files>
    <source id="1" name="contract.pdf" resource-type="file" resource-id="file-abc">…full body…</source>
    <source id="2" name="kb-a-doc" resource-type="collection" resource-id="kb-uuid">…full body…</source>
  </full_context_files>
  <available_files>
    <attached_file id="file-def" name="appendix.pdf" resource-type="file" mode="retrievable">Use query_attached_files with this id to inspect or search this item.</attached_file>
    <attached_file id="kb-other" name="my-knowledge-base" resource-type="collection" mode="retrievable">Use query_attached_files with this id to inspect or search this item.</attached_file>
  </available_files>
</context>
```

Two sub-blocks with two different cache profiles:

- **`<full_context_files>`** holds citeable content. `<source id="N">` tags with full bodies, identical to today's source format. These are full-context files, full-context knowledge bases, and natively-full types (`text`/`note`/`chat`/`url`). They are static for the lifetime of the chat — they only change when the user adds/removes/toggles an attachment.
- **`<available_files>`** holds inventory listings. `<attached_file id="…">` tags with a one-line hint pointing at `query_attached_files`. **No body content.** Critically, these are **not** `<source>` tags — the rendered RAG template's citation guidance only applies to `<source id="…">`, so the model has no incentive to fabricate citations against entries that have no evidence in them. To use an attached file as evidence, the model must first call `query_attached_files` and cite from the `<source id="…">` tags in the tool result.

`DEFAULT_RAG_TEMPLATE` gains exactly one bullet point in the citation guidelines clarifying this distinction. Custom `RAG_TEMPLATE` values (env or admin-configured) are not touched.

### Fix Scenario 1 + Scenario 2 — always route to the system prompt in native FC mode

In native FC mode the rendered template is forced into the system prompt regardless of `RAG_SYSTEM_CONTEXT`. The relevant call site:

```python
form_data['messages'] = await apply_source_context_to_messages(
    request,
    form_data['messages'],
    sources,
    prompt,
    force_system_message=native_fc_with_builtins,
)
```

This eliminates Scenario 1: nothing prepends to the last user message anymore, so the second-newest user message no longer mutates between turns.

It would *also* trip Scenario 2 except that the volatile retrieval chunks are no longer in the system prompt — they have been moved out (see below). The system prompt now contains only:

- citation instructions (static, identical across the lifetime of `RAG_TEMPLATE`),
- full-context file bodies (static until the file set changes),
- the queryable file roster (static until the file set changes).

All three parts change at the same cadence: only when the user adds, removes, or toggles an attachment. That's typically zero times during the chat. When it does happen, the cost is one turn of cache invalidation, then stable again.

### Fix Scenario 2's chunked-retrieval problem — route chunks through `query_attached_files` instead

The mutating chunks are the root cause of Scenario 2. The fix is to stop auto-retrieving them and route the retrieval through an immutable tool call instead.

In `chat_completion_files_handler`, items are partitioned via a single predicate:

```python
RETRIEVABLE_TYPES = {'file', 'collection'}
should_partition = native_function_calling_with_builtins and not force_full_context

def is_retrievable(item):
    return (
        item.get('context') != 'full'
        and item.get('type') in RETRIEVABLE_TYPES
    )

if should_partition:
    retrievable_items = [item for item in files if is_retrievable(item)]
    full_context_items = [item for item in files if not is_retrievable(item)]
else:
    retrievable_items = []
    full_context_items = list(files)
```

- **Full-context items** (and natively-full types like notes, raw text uploads, attached chats, URLs, and any unknown future item type) keep going through `get_sources_from_items` with `full_context=True`. Bodies land in `<full_context_files>` as `<source>` tags. Unchanged from today's behavior for these items.
- **Chunked-retrieval items** (`file` or `collection` with `context != 'full'`) **skip retrieval entirely**. They get a roster-only source entry (`{'source': {…}, 'roster_only': True}`) that `get_source_context` renders as an `<attached_file>` tag inside `<available_files>`. No chunks are pulled at this stage. No volatile content enters the system prompt.

A new builtin tool **`query_attached_files(query, ids?, count?)`** is added to `backend/open_webui/tools/builtin.py` and registered by `get_builtin_tools` whenever the chat has retrievable items. It is the model's mechanism to actually read the content of items in `<available_files>` when it judges the user query needs them. The tool's implementation:

- **Per-item access control**, matching `view_file` / `view_knowledge_file` posture: `type='file'` items go through `_has_read_access_to_file(user_id, user_role)` (deliberately *not* `__model_knowledge__` — this is chat-scope, not model-scope); `type='collection'` items go through owner / admin / `AccessGrants.has_access(resource_type='knowledge', permission='read')`. Items the user can't read are silently skipped.
- Receives the retrievable item list via the existing `extra_params` plumbing as `__attached_files__`, matching the pattern already used by `query_knowledge_files`'s `__model_knowledge__`.
- Optionally scopes by `ids` (the literal value of the `id` attribute on `<attached_file id="…">` entries in the system context). Omitted or empty list = search every attached item, matching API convention.
- **`count` defaults to the admin-configured retrieval `TOP_K` and is clamped to that value as a ceiling** — a model cannot exceed the admin's configured retrieval budget.
- **Hybrid search and reranking are inherited automatically** — the tool calls `query_collection`, which internally routes to `query_collection_with_hybrid_search` with the admin's `TOP_K_RERANKER`, `RELEVANCE_THRESHOLD`, `HYBRID_BM25_WEIGHT`, and `RERANKING_FUNCTION` whenever `ENABLE_RAG_HYBRID_SEARCH` is on. No additional plumbing required.
- Resolves `type='file'` items to the `file-{id}` collection name and `type='collection'` items to the KB id (or the explicit `collection_names` list for legacy multi-collection KBs). Returns chunks with `{content, source, file_id, distance}` — same shape as `query_knowledge_files`.

`query_attached_files` is also wired into `get_citation_source_from_tool_result` so its chunks flow into the source/citation pipeline the same way `query_knowledge_files`'s do — the citation prompt's "cite from `<source id="...">`" instruction works for tool-derived content as well.

The cache benefit: every `query_attached_files` invocation produces a `tool_call` + `tool_result` pair that becomes part of the chat history. Tool calls and tool results are **immutable** — once they exist in history, their bytes never change. So from the iteration after a tool call onward, that tool call and its result cache forever. A long chat with many file retrievals over time produces a long sequence of immutable cached tool pairs, each one a permanent prefix extension. No volatile content anywhere.

### Fix Scenario 3 — stop re-rendering the RAG template on every tool-loop iteration

In native FC mode the tool-loop's per-iteration RAG re-application is skipped entirely:

```python
all_tool_call_sources.extend(tool_call_sources)
skip_rag_reapply = metadata.get('native_fc_with_builtins', False)
if not skip_rag_reapply and all_tool_call_sources and user_message:
    # existing code path: restore system + user, rebuild source_context,
    # re-apply rag_template, inject per RAG_SYSTEM_CONTEXT.
    …
```

The empty `<source id="N"/>` markers that the existing code added per iteration carried no information. The actual content lives in the tool result message. The source/filename/file_id metadata lives in the tool result JSON. Citation by `[N]` was the only thing the markers enabled, and that's now handled cleanly: `query_attached_files` tool results are parsed by `get_citation_source_from_tool_result` and contribute proper `<source id="N">` citation sources to the events stream the frontend renders.

Result: from the second tool-loop iteration onward, the **entire prefix through the previous tool result is byte-identical** to the previous iteration. Every provider cache-hits the full prefix. Only the new `tool_call` + `tool_result` pair is new content per iteration. A 10-tool-call research turn that today costs 10 full prefix recomputes now costs the prefix once at iteration 1 plus N small tool-pair extensions.

---

## What gets cached after this PR, per scenario

| Situation | Today (default `RAG_SYSTEM_CONTEXT=false`) | Today (`RAG_SYSTEM_CONTEXT=true`) | After this PR (native FC mode) |
|---|---|---|---|
| New turn, no attachment changes, no tool calls | Second-newest user message mutated → cache breaks there. Files re-billed every turn. | If only full-context items: full hit. If any chunked items: system mutates → entire cache miss every turn. | Full hit. System prompt and all prior history cached. Only new user msg + assistant response are new content. |
| New turn, user added/removed/toggled an attachment | Same as above (second-newest user msg always mutates anyway). | 1 turn of system-prompt invalidation, then stable. | 1 turn of system-prompt invalidation, then stable. |
| Turn with N tool calls | Per-iteration RAG mutation on top of the user-msg mutation. ~N+1 cache breaks within the turn. | Per-iteration system-prompt mutation on top of any chunked-retrieval mutation. ~N+1 cache breaks within the turn. | Iteration 1 is new content (initial system + first tool pair). Iterations 2..N hit the entire prefix through iteration N-1's tool result and only add the new tool pair. |
| Long chat, mostly file Q&A | Files never cached. Most input is file content. Most input is re-billed every turn. | Either files are full-context (cache hits) or chunks invalidate system (cache misses). No mixed mode. | Full-context bodies in system: cached. Chunked retrievals via tool calls: cached as immutable tool pairs in history. Both modes coexist cleanly. |

---

## Backward compatibility — default and prompt-based FC mode behavior is preserved EXACTLY

The new path is activated by a single boolean computed in `process_chat_payload`:

```python
capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
builtin_tools_enabled = capabilities.get('builtin_tools', True)
file_context_enabled = capabilities.get('file_context', True)
is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'

force_full_context = (
    request.app.state.config.RAG_FULL_CONTEXT
    or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
)

native_fc_with_builtins = (
    not payload_tools
    and is_native_fc
    and builtin_tools_enabled
    and file_context_enabled
    and not force_full_context
)
```

When **any** of these conditions is false, `native_fc_with_builtins` is False and every modified code path falls through to the existing implementation byte-for-byte:

- `chat_completion_files_handler` takes the non-partition branch: every item in `body.metadata.files` runs through `get_sources_from_items` exactly as today, honoring per-item `context` flags and `RAG_FULL_CONTEXT` / `BYPASS_EMBEDDING_AND_RETRIEVAL`. Chunks for chunked items, full bodies for full-context items. Same `sources` shape as before — no `roster_only` flag, no `<attached_file>` tags, no partition.
- `apply_source_context_to_messages` takes `force_system_message=False`, falling back to the existing `if RAG_SYSTEM_CONTEXT: append to system else: prepend to last user` logic.
- `get_source_context` only emits the `<full_context_files>` / `<available_files>` split shape when at least one source has `roster_only=True`. When all sources are regular content sources (which is what the existing path produces), the output is the flat `<source>` shape it has always emitted: `if not roster_parts: return ''.join(citeable_parts)`.
- The tool-loop reads `metadata.get('native_fc_with_builtins', False)`. When False, it runs the original restore + rebuild + re-apply code exactly as before, including the `RAG_SYSTEM_CONTEXT` branch for where to inject.
- `query_attached_files` is only registered by `get_builtin_tools` when the chat has retrievable items (i.e., `__attached_files__` is populated AND at least one item has `type in ('file', 'collection')` with `context != 'full'` AND `force_full_context` is False). In default mode none of those conditions are met.
- `DEFAULT_RAG_TEMPLATE` gains one bullet point. Custom `RAG_TEMPLATE` env vars and admin-configured templates are **not** modified.

### Why `not payload_tools` is in the gate

When the caller (a pipe function, a direct API client, a custom integration) provides its own `tools` array in the request body, the `if not payload_tools:` block that resolves server-side tools (including builtins) is skipped entirely — meaning `query_attached_files` is never registered. If we activated the new path without this gate, the system prompt would contain an `<available_files>` roster telling the model "call `query_attached_files`" while the tool literally would not exist in the model's `tools` array. The model would either hallucinate the call or apologize. This gate is correctness, not policy. A future PR could lift it by extending the `payload_tools` branch to also register select builtins.

### How `RAG_FULL_CONTEXT=true` and `BYPASS_EMBEDDING_AND_RETRIEVAL=true` interact with the new path

Both flags are treated identically — they're combined into one local `force_full_context` because `retrieval/utils.py:1219` and `:1275` already treat them as the same condition (full content instead of chunked retrieval) for `file` and `collection` items. When either is on, `native_fc_with_builtins` is False, and the new path reverts to pre-PR behavior end-to-end:

- Partition is skipped — every item goes through `get_sources_from_items` with `full_context=True`.
- `apply_source_context_to_messages` honors `RAG_SYSTEM_CONTEXT` (pre-PR placement, default user-message).
- The tool-loop runs its original per-iteration re-application.
- `query_attached_files` is not registered (no retrievable items).
- `get_source_context` emits the flat `<source>` shape (no roster sources).

This was an explicit design choice: under `RAG_FULL_CONTEXT` / `BYPASS_EMBEDDING_AND_RETRIEVAL` there is no chunked retrieval to push into a tool, so the optimization has no relevant work to do. Preserving the existing semantics for these admin modes is more valuable than the marginal cache win that would come from also forcing system-prompt placement in this case.

---

## What this PR explicitly does **not** do

- **It does not emit Anthropic `cache_control` markers.** Open WebUI has no provider-specific cache marker emission anywhere in the codebase. This PR produces a stable, cacheable prefix shape; turning that shape into actual Anthropic cache hits requires emitting `cache_control: {type: "ephemeral"}` breakpoints at end-of-system and after the last assistant message. That's a provider-specific concern and belongs in an outlet filter or upstream proxy (LiteLLM/OpenRouter/etc.) per OWUI's general architecture — not in core. Deployments going to OpenAI or Gemini benefit from this PR immediately (their caching is implicit/automatic on stable prefixes); Anthropic deployments need the additional marker step, which is straightforward against the stable prefix this PR produces.
- **It does not change default/prompt-based FC mode behavior in any way.** No new flags, no new gates, no new tags, no new tools. Existing deployments not on native FC mode see no behavior change.
- **It does not change `RAG_FULL_CONTEXT` or `BYPASS_EMBEDDING_AND_RETRIEVAL` deployment behavior.** Either flag on → identical to pre-PR pipeline.
- **It does not modify custom `RAG_TEMPLATE` values.** Only `DEFAULT_RAG_TEMPLATE` gains one bullet point. Any deployment that has overridden the template keeps theirs intact.
- **It does not add tests.** The repo has no backend test infrastructure to plug into; verification is by-inspection and manual smoke against the scenarios in the test plan.

---

## Files changed

- `backend/open_webui/config.py` — `DEFAULT_RAG_TEMPLATE` gains one citation guideline distinguishing `<source>` from `<attached_file>`.
- `backend/open_webui/utils/middleware.py`
  - `_format_tag_attrs` — small helper for conditional XML attribute emission, used by both `<source>` and `<attached_file>` rendering paths.
  - `_ROSTER_HINT` — module-level constant for the inventory hint text rendered into `<attached_file>` bodies.
  - `get_source_context` — detects `roster_only` sources and emits the `<full_context_files>` / `<available_files>` split when any roster source is present; flat `<source>` shape otherwise (backward compatible).
  - `apply_source_context_to_messages` — new `force_system_message` kwarg, defaults to False; pins template to the system prompt when True regardless of `RAG_SYSTEM_CONTEXT`.
  - `get_citation_source_from_tool_result` — `query_attached_files` added to `_EXPECTS_LIST` and to the dispatch branch that already handles `query_knowledge_files` (they return identical chunk shape).
  - `chat_completion_files_handler` — new `native_function_calling_with_builtins` kwarg. When True and `force_full_context` is False, partitions items via a single `is_retrievable` predicate; runs retrieval only on full-context items, emits `roster_only` source entries (id/type/name only, no `document`/`metadata`) for the rest.
  - `process_chat_payload` — hoists `capabilities` / `builtin_tools_enabled` / `file_context_enabled` / `is_native_fc` to a single set of named locals; computes `force_full_context` and `native_fc_with_builtins`; passes `__attached_files__` to `get_builtin_tools`; stashes the flag in `metadata['native_fc_with_builtins']` for the streaming handler; passes the right kwargs to `chat_completion_files_handler` and `apply_source_context_to_messages`. The tool-call dispatch site is also updated to recognize `query_attached_files` for citation extraction.
  - Tool-call loop in `streaming_chat_response_handler` — reads `metadata['native_fc_with_builtins']`. When True, skips restoration of the system prompt and the per-iteration RAG template re-application. Existing path preserved verbatim under `elif`.
- `backend/open_webui/utils/tools.py` — `get_builtin_tools` reads `__attached_files__` from `extra_params`, computes the retrievable subset (filtered by `RAG_FULL_CONTEXT` / `BYPASS_EMBEDDING_AND_RETRIEVAL`), appends `query_attached_files` to `builtin_functions` when the retrievable subset is non-empty, threads `__attached_files__` into each tool's extras alongside the existing `__model_knowledge__`.
- `backend/open_webui/tools/builtin.py` — new `query_attached_files(query, ids?, count?)` builtin tool.
  - **Access control:** `_has_read_access_to_file` per file item (chat-scoped — deliberately omits `__model_knowledge__`); owner / admin / `AccessGrants` per collection item.
  - **Param semantics:** `query` required; `ids` optional, omitted-or-empty searches every attached item, non-empty list scopes; `count` optional, defaults to admin `TOP_K`, clamped to that as a ceiling.
  - **Hybrid search:** inherited automatically from `query_collection` (which routes to `query_collection_with_hybrid_search` when `ENABLE_RAG_HYBRID_SEARCH` is on).
  - **Return shape:** identical to `query_knowledge_files` — JSON list of `{content, source, file_id, distance}` chunks.
  - **Docstring:** the model-facing description explicitly marks each param required/optional, spells out that `ids` takes the literal id string from `<attached_file id="...">` (not the wrapping tag), and states the default-all-attached behavior up front.

## Test plan

- [ ] Default FC mode + chunked files, `RAG_SYSTEM_CONTEXT=false`: verify chunks still injected into last user message exactly as today (unchanged from main).
- [ ] Default FC mode + chunked files, `RAG_SYSTEM_CONTEXT=true`: verify chunks still injected into system prompt exactly as today (unchanged from main).
- [ ] Default FC mode + full-context files: verify full bodies still injected per `RAG_SYSTEM_CONTEXT` (unchanged from main).
- [ ] Default FC mode + tool calls + files: verify the existing tool-loop RAG re-application still runs per iteration (unchanged from main).
- [ ] Native FC mode + only full-context files: verify system prompt contains `<full_context_files>` with `<source>` bodies, no `<available_files>` block, no `query_attached_files` tool registered.
- [ ] Native FC mode + only chunked files: verify system prompt contains `<available_files>` roster of `<attached_file>` entries, no `<full_context_files>`, no chunks injected up front, `query_attached_files` registered and callable.
- [ ] Native FC mode + mixed full and chunked: both blocks present in the system prompt, `query_attached_files` registered, model can read full-context bodies directly and call the tool for chunked items.
- [ ] Native FC mode + chunked knowledge base attached to the chat: KB appears as `<attached_file resource-type="collection" id="…">` in `<available_files>`, `query_attached_files(ids=["kb-id"])` returns chunks from that KB only.
- [ ] Native FC mode + research-style turn with many tool calls: capture outgoing requests across iterations and confirm the system prompt is byte-identical from iteration 1 onward. Only the new `tool_call` + `tool_result` pair should be new content per iteration.
- [ ] Native FC mode + `query_attached_files` result citations: confirm `get_citation_source_from_tool_result` produces `<source id="N">` entries for the tool's chunks and the frontend renders them in the citations panel.
- [ ] Native FC mode + `query_attached_files` with `count` higher than admin `TOP_K`: verify `count` is silently clamped down to `TOP_K`.
- [ ] Native FC mode + `query_attached_files` with `ids=[]` or `ids` omitted: verify the search runs across every attached item.
- [ ] Native FC mode + `query_attached_files` with an id the user doesn't have read access to: verify the item is silently skipped from results.
- [ ] Native FC mode + `RAG_FULL_CONTEXT=true` admin global: verify `native_fc_with_builtins` evaluates to False, placement honors `RAG_SYSTEM_CONTEXT`, tool-loop runs its pre-PR per-iteration re-application, `query_attached_files` is not registered, all items render as flat `<source>` tags.
- [ ] Native FC mode + `BYPASS_EMBEDDING_AND_RETRIEVAL=true` admin global: identical behavior to the previous bullet.
- [ ] Verify `<attached_file>` entries never appear inside `<source>` tags. Model should not produce `[id]` citations against roster entries.
- [ ] Verify caller-supplied `tools` payload (non-empty `payload_tools` in the request body) short-circuits `native_fc_with_builtins` to False and routes through the unchanged default path.
- [ ] Verify a non-default `RAG_TEMPLATE` (configured via env or admin settings) is not modified by the citation-guideline addition — only the literal `DEFAULT_RAG_TEMPLATE` constant changes.
- [ ] Verify file attachment add/remove/toggle mid-chat: produces one turn of system-prompt invalidation, then the system prompt is stable again from the next turn forward.
- [ ] Verify `text`/`note`/`chat`/`url` attachment types continue to be treated as full-content (they have no chunked-retrieval mode) and land in `<full_context_files>`.