### PR TITLE
fix: fix in get_sources_from_items collection paths

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1252,11 +1252,23 @@ async def get_sources_from_items(
                             ],
                         }
             else:
-                # Fallback to collection names
-                if item.get('legacy'):
-                    collection_names.append(f'{item["id"]}')
-                else:
-                    collection_names.append(f'file-{item["id"]}')
+                # Chunked-retrieval fallback. body.metadata.files is client-
+                # controlled, so a caller could attach an arbitrary file id and
+                # query its vector collection. Require read access on the file
+                # before exposing its collection — same posture as the
+                # full-context branch above.
+                file_id = item.get('id')
+                if file_id:
+                    file_object = await Files.get_file_by_id(file_id)
+                    if file_object and (
+                        user.role == 'admin'
+                        or file_object.user_id == user.id
+                        or await has_access_to_file(file_id, 'read', user)
+                    ):
+                        if item.get('legacy'):
+                            collection_names.append(f'{file_id}')
+                        else:
+                            collection_names.append(f'file-{file_id}')
 
         elif item.get('type') == 'collection':
             # Manual Full Mode Toggle for Collection
@@ -1302,9 +1314,25 @@ async def get_sources_from_items(
                             'metadatas': [metadatas],
                         }
                 else:
-                    # Fallback to collection names
                     if item.get('legacy'):
-                        collection_names = item.get('collection_names', [])
+                        # Legacy KB: item.collection_names is client-supplied
+                        # and would otherwise let a caller substitute arbitrary
+                        # vector collection names (e.g. file-<victim_id>) while
+                        # holding access only to the parent KB. Filter the
+                        # supplied names against what the verified KB actually
+                        # owns; drop anything outside that set.
+                        supplied = item.get('collection_names') or []
+                        kb_files = await Knowledges.get_files_by_id(knowledge_base.id)
+                        owned = {f'file-{f.id}' for f in kb_files}
+                        owned.add(knowledge_base.id)
+                        validated = [name for name in supplied if name in owned]
+                        if validated:
+                            collection_names = validated
+                        else:
+                            # Either no names supplied or all were spoofed —
+                            # fall back to the KB id, which the access check
+                            # above already validated.
+                            collection_names.append(knowledge_base.id)
                     else:
                         collection_names.append(item['id'])
 
@@ -1315,8 +1343,19 @@ async def get_sources_from_items(
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
         elif item.get('collection_name'):
-            # Direct Collection Name
-            collection_names.append(item['collection_name'])
+            # WARNING: removed unauthenticated direct-collection-name
+            # passthrough. Previously this branch trusted the client-supplied
+            # `collection_name` field and queried it without any ownership
+            # check, letting a caller read arbitrary vector collections
+            # (e.g. file-<victim_id>) by attaching a bare item to the chat.
+            # Legitimate flows route through type='file' or type='collection'
+            # which carry the proper access checks; items reaching this
+            # branch without a recognized type are no longer trusted.
+            log.debug(
+                'get_sources_from_items: ignoring untrusted direct '
+                "collection_name '%s' on item without type",
+                item.get('collection_name'),
+            )
         elif item.get('collection_names'):
             # Collection Names List
             collection_names.extend(item['collection_names'])


### PR DESCRIPTION
# Fix BOLA vulnerabilities in `get_sources_from_items`

Three caller-controlled paths inside `backend/open_webui/retrieval/utils.py:get_sources_from_items` allow an authenticated user to query vector collections they don't own by crafting `body.metadata.files` items in a chat completion request. All three follow the same pattern: a field from the request item dict is concatenated or used as-is to form a vector collection name and passed to `query_collection`, without re-validating that the user has read access to the underlying resource.

This PR closes all three.

## Attack surface

### 1. Chunked file path — no ownership check at all

`retrieval/utils.py` previously did:

```python
elif item.get('type') == 'file':
    if item.get('context') == 'full' or BYPASS_EMBEDDING_AND_RETRIEVAL:
        # full-context paths — already access-checked via has_access_to_file
        ...
    else:
        # Fallback to collection names — NO ACCESS CHECK
        if item.get('legacy'):
            collection_names.append(f'{item["id"]}')
        else:
            collection_names.append(f'file-{item["id"]}')
```

A caller could attach `{"type": "file", "id": "<victim_file_id>", "context": "chunked"}` and `query_collection` would return chunks from the victim's `file-{victim_file_id}` collection. The full-context path on the same `elif` branch already does the right access check (`user.role == 'admin' or file_object.user_id == user.id or has_access_to_file(...)`); the chunked path skipped it entirely.

**Fix:** identical access check before appending the collection name.

### 2. Legacy collection path — client-supplied `collection_names` trusted

`retrieval/utils.py` previously did:

```python
elif item.get('type') == 'collection':
    knowledge_base = await Knowledges.get_knowledge_by_id(item.get('id'))
    if knowledge_base and (... access check on KB id ...):
        if item.get('context') == 'full' or BYPASS:
            ...
        else:
            if item.get('legacy'):
                collection_names = item.get('collection_names', [])
            else:
                collection_names.append(item['id'])
```

The KB access check on `item['id']` passes (caller owns or has read on that KB), but the legacy branch then reads `item.get('collection_names', [])` directly from the request item and queries those collections. A caller can legitimately own KB `kb-mine` and inject `collection_names=['file-<victim_id>']` to read collections that have nothing to do with their KB.

**Fix:** validate the supplied list against the set of collection names the verified KB actually owns — `{f'file-{f.id}' for f in Knowledges.get_files_by_id(kb.id)} ∪ {kb.id}`. Drop anything outside that set. If nothing legitimate remains, fall back to the KB id (which the access check above already validated).

### 3. Direct `collection_name` (singular) passthrough — zero validation

```python
elif item.get('collection_name'):
    # Direct Collection Name
    collection_names.append(item['collection_name'])
```

This is the most permissive case: any item containing a `collection_name` string had it appended to the query list with no upstream type tag, no access check, no ownership context. A caller could attach `{"collection_name": "file-<victim_id>"}` and read it.

Legitimate flows attach via `type='file'` or `type='collection'`, which carry the proper checks. The middleware pre-processes `model_knowledge` items with bare `collection_name` into items with `id` set (`middleware.py:~2482`), so legitimate `collection_name`-only items don't actually reach this branch — the path was a residual untrusted passthrough.

**Fix:** removed the trust. Items reaching this branch without a recognized type are logged and skipped.

## Behavior changes

- Callers that route through `type='file'` or `type='collection'` with legitimately owned items: **no change**.
- Callers that exploited any of the three paths to read collections outside the verified parent's ownership: those calls now drop. That's the intended behavior.
- Callers (if any) that relied on the bare `collection_name` passthrough for legitimate chat flows: those calls drop. The legitimate model_knowledge path through middleware translates `collection_name` → `id` before reaching this function, so legitimate flows are unaffected.

## Out of scope

`backend/open_webui/tools/builtin.py:query_knowledge_files` already uses `item_id` (the KB id) directly as the collection name — no `collection_names` trust there, so it's not vulnerable to issue #2. It does inherit access checks correctly via the KB owner / admin / `AccessGrants` flow.

`backend/open_webui/tools/builtin.py:query_attached_files` (added in #194, not yet merged) had the same `collection_names` trust issue as path #2; the corresponding fix is being applied in that PR's branch so the new tool doesn't introduce the vulnerability when it lands.

## Test plan

- [ ] Attach a chunked file the user owns via the normal chat UI: retrieval still returns its chunks.
- [ ] Attach a chunked file via a crafted request body where `id` is a file the user does NOT have read access to: retrieval returns empty for that file (silently dropped).
- [ ] Attach a legacy collection (`type='collection'`, `legacy=True`) where `collection_names` matches the KB's actual file collections: those collections are queried.
- [ ] Attach a legacy collection where `collection_names` contains a spoofed `file-<victim_id>`: the spoofed entry is filtered out, only legitimate entries (or KB id fallback) are queried.
- [ ] Send an item with only `collection_name` set (no `type`): the item is silently skipped with a debug log line; query returns no results from that item.
- [ ] Normal full-context file attachment: unchanged from main.
- [ ] Normal full-context collection attachment: unchanged from main.
- [ ] `BYPASS_EMBEDDING_AND_RETRIEVAL=true`: full-content paths execute as before.
- [ ] Admin user: access checks pass for any file/KB (existing `user.role == 'admin'` bypass).

## Related

Companion to #194 (cache-optimal file context routing) which adds a new builtin tool that previously inherited the same `collection_names` trust pattern. That PR's branch applies the same fix to its tool so the new code doesn't introduce a regression.

Adjacent to #25113 which patches a different BOLA in `search_knowledge_files` (caller-supplied `knowledge_id` parameter). Distinct attack surface; this PR is the broader retrieval-path fix.

https://claude.ai/code/session_01K8sXWeXxkwYjBXnNSpbyS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8sXWeXxkwYjBXnNSpbyS2)_