### PR TITLE
fix: pass web search results to model when embedding & retrieval enabled

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1374,6 +1374,10 @@ async def get_sources_from_items(
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
+        elif item.get('type') == 'web_search' and item.get('collection_name'):
+            # Trusted server-generated collection; authorized by
+            # filter_accessible_collections below (allowlists web-search-*).
+            collection_names.append(item['collection_name'])
         elif item.get('collection_name'):
             if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                 collection_names.append(item['collection_name'])


### PR DESCRIPTION
## Problem

After 0.9.6, web search results are fetched and embedded (logs show `added N items to collection web-search-...`) but never reach the model — it answers as if no search ran. Reported in #25585. Only affects the **legacy/default** tool-calling path with **Embedding and Retrieval enabled**; native FC and "Bypass Embedding and Retrieval" are unaffected.

## Root cause

The 0.9.6 retrieval access-control hardening gated the bare `collection_name` fallback in `get_sources_from_items` behind `BYPASS_RETRIEVAL_ACCESS_CONTROL` (default `False`) to reject untrusted **client-supplied** collection names.

The web-search file item (`{'collection_name': 'web-search-<hash>', 'type': 'web_search', ...}`) is generated **server-side** by `process_web_search`, but `type == 'web_search'` matches none of the explicit dispatch branches, so it falls through to that untrusted-name branch and gets silently dropped.

This explains every symptom in the issue:
- **Bypass mode works** — the item carries `docs` and hits the `elif item.get('docs')` branch instead.
- **Native FC works** — web search runs as a builtin tool (cited via `get_citation_source_from_tool_result`), not the collection path.
- **Legacy FC + embedding breaks** — the only path that reaches the gated `collection_name` branch.

## Fix

Add an explicit branch for `type == 'web_search'` items so the collection is queried again. Access control is preserved: the collection still flows through `filter_accessible_collections`, which already allowlists `web-search-*` and bypasses only for admins. `BYPASS_RETRIEVAL_ACCESS_CONTROL` stays off by default — the untrusted-client-name protection is unchanged.

Fixes #25585

https://claude.ai/code/session_01UNgqqJwGKJ5ZnGMcMQ3dTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNgqqJwGKJ5ZnGMcMQ3dTW)_