### PR TITLE
Make Native the default tool-calling mode; rename "Default" to "Legacy"

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1790,12 +1790,12 @@ async def chat_completion(
                 'stream_delta_chunk_size': stream_delta_chunk_size,
                 'reasoning_tags': reasoning_tags,
                 'function_calling': (
-                    'native'
+                    'legacy'
                     if (
-                        form_data.get('params', {}).get('function_calling') == 'native'
-                        or model_info_params.get('function_calling') == 'native'
+                        form_data.get('params', {}).get('function_calling') == 'legacy'
+                        or model_info_params.get('function_calling') == 'legacy'
                     )
-                    else 'default'
+                    else 'native'
                 ),
             },
         }

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -150,7 +150,7 @@
 	<div>
 		<Tooltip
 			content={$i18n.t(
-				"Default mode works with a wider range of models by calling tools once before execution. Native mode leverages the model's built-in tool-calling capabilities, but requires the model to inherently support this feature."
+				"Legacy mode works with a wider range of models by calling tools once before execution. Native mode leverages the model's built-in tool-calling capabilities, but requires the model to inherently support this feature."
 			)}
 			placement="top-start"
 			className="inline-tooltip"
@@ -162,14 +162,14 @@
 				<button
 					class="p-1 px-3 text-xs flex rounded-sm transition"
 					on:click={() => {
-						params.function_calling = (params?.function_calling ?? null) === null ? 'native' : null;
+						params.function_calling = params?.function_calling === 'legacy' ? null : 'legacy';
 					}}
 					type="button"
 				>
-					{#if params.function_calling === 'native'}
-						<span class="ml-2 self-center">{$i18n.t('Native')}</span>
+					{#if params.function_calling === 'legacy'}
+						<span class="ml-2 self-center">{$i18n.t('Legacy')}</span>
 					{:else}
-						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+						<span class="ml-2 self-center">{$i18n.t('Native')}</span>
 					{/if}
 				</button>
 			</div>


### PR DESCRIPTION
- Native is now the default function-calling mode for all deployments: the backend resolves an empty/absent function_calling to native and only uses the legacy path when something explicitly requests 'legacy'.
- Rename the former "Default" tool-calling mode to "Legacy" (now the explicit opt-out) in the toggle label and tooltip.
- Update the AdvancedParams toggle to write null (native) <-> 'legacy'.

Existing installs (all stored as null/absent) simply resolve to native; admins/users can opt back to legacy per chat, per model, or globally via Default Model Params.