### PR TITLE
fix: Improve tool server error logging with exception details

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1264,7 +1264,7 @@ async def get_tool_server_data(url: str, headers: dict | None) -> dict[str, Any]
                         res = yaml.safe_load(text_content)
 
     except Exception as err:
-        log.exception(f'Could not fetch tool server spec from {url}')
+        log.warning(f'Could not fetch tool server spec from {url}: {err}')
         if isinstance(err, dict) and 'detail' in err:
             error = err['detail']
         else:


### PR DESCRIPTION
## Description

This PR improves error logging when fetching tool server specifications fails. The change replaces `log.exception()` with `log.warning()` and includes the exception details in the log message, providing better visibility into what went wrong without the full stack trace.

## Changes

### Fixed

- Changed error logging level from `exception` to `warning` when tool server spec fetch fails
- Added exception details (`{err}`) to the log message for better debugging without full stack traces

## Motivation

The previous implementation used `log.exception()` which logs the full stack trace. For expected error conditions (like network failures or invalid server responses), a warning-level log with the error details is more appropriate and reduces noise in logs while still providing useful debugging information.

## Testing

No testing needed - this is a logging improvement that doesn't affect functionality.

## Checklist

- [x] Targets the `dev` branch
- [x] Self-review completed
- [x] No breaking changes
- [x] Minimal, focused change

---

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

https://claude.ai/code/session_01QVtSDUwwvkcaMmP5e1GomE