### PR TITLE
fix: align OCR dependency with langchain-community (rapidocr-onnxruntime → rapidocr)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -88,7 +88,7 @@ soundfile==0.13.1
 
 pillow==12.2.0
 opencv-python-headless==4.13.0.92
-rapidocr-onnxruntime==1.4.4
+rapidocr==3.9.1
 rank-bm25==0.2.2
 
 onnxruntime==1.26.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
 
     "pillow==12.2.0",
     "opencv-python-headless==4.13.0.92",
-    "rapidocr-onnxruntime==1.4.4",
+    "rapidocr==3.9.1",
     "rank-bm25==0.2.2",
 
     "onnxruntime==1.26.0",

--- a/uv.lock
+++ b/uv.lock
@@ -179,6 +179,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034 }
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -841,6 +847,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743 },
 ]
 
 [[package]]
@@ -2942,6 +2960,19 @@ wheels = [
 ]
 
 [[package]]
+name = "omegaconf"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502 },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3045,7 +3076,7 @@ dependencies = [
     { name = "pytz" },
     { name = "pyxlsb" },
     { name = "rank-bm25" },
-    { name = "rapidocr-onnxruntime" },
+    { name = "rapidocr" },
     { name = "redis" },
     { name = "requests" },
     { name = "restrictedpython" },
@@ -3199,7 +3230,7 @@ requires-dist = [
     { name = "pyxlsb", specifier = "==1.0.10" },
     { name = "qdrant-client", marker = "extra == 'all'", specifier = "==1.18.0" },
     { name = "rank-bm25", specifier = "==0.2.2" },
-    { name = "rapidocr-onnxruntime", specifier = "==1.4.4" },
+    { name = "rapidocr", specifier = "==3.9.1" },
     { name = "redis", specifier = "==8.0.0" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "restrictedpython", specifier = "==8.2" },
@@ -4650,22 +4681,24 @@ wheels = [
 ]
 
 [[package]]
-name = "rapidocr-onnxruntime"
-version = "1.4.4"
+name = "rapidocr"
+version = "3.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "colorlog" },
     { name = "numpy" },
-    { name = "onnxruntime" },
+    { name = "omegaconf" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pyclipper" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "shapely" },
     { name = "six" },
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/12/1e5497183bdbe782dbb91bad1d0d2297dba4d2831b2652657f7517bfc6df/rapidocr_onnxruntime-1.4.4-py3-none-any.whl", hash = "sha256:971d7d5f223a7a808662229df1ef69893809d8457d834e6373d3854bc1782cbf", size = 14915192 },
+    { url = "https://files.pythonhosted.org/packages/a0/23/e8d7251c53137b5b66d89e85cb0bc3e6bcfaec9527f29b477ec04389c8b2/rapidocr-3.9.1-py3-none-any.whl", hash = "sha256:600885e4e94e0b427abad394fccb0ec1d3c9118a215ca435bf7680aeae0e292b", size = 27274755 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26646
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No docs changes needed (dependency-only fix).
- [x] **Dependencies:** Dependency change explained below.
- [x] **Testing:** Verified the lockfile resolves cleanly (`uv lock --check`) and the import path (`from rapidocr import RapidOCR`) that langchain-community uses is satisfied by the new package.
- [x] **No Unchecked AI Code:** Reviewed and tested.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings; drop-in dependency alignment.
- [x] **Git Hygiene:** Atomic, based on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- After the LangChain upgrade in v0.10.x, `langchain-community` resolves the OCR engine via `from rapidocr import RapidOCR`, but the image still shipped the legacy `rapidocr-onnxruntime` package. As a result, uploading a PDF with **PDF Extract Images (OCR)** enabled failed with `ModuleNotFoundError: No module named 'rapidocr'`, forcing users to manually `pip install rapidocr` inside the container as a workaround.

### Changed

- Replaced `rapidocr-onnxruntime==1.4.4` with its successor package `rapidocr==3.9.1` in `pyproject.toml`, `backend/requirements.txt`, and `uv.lock`, so OCR image extraction works out-of-the-box. The `onnxruntime` backend `rapidocr` uses at runtime remains satisfied by the existing pinned `onnxruntime` dependency.

### Removed

- `rapidocr-onnxruntime` dependency (superseded by `rapidocr`).

### Fixed

- PDF upload with OCR image extraction enabled no longer fails with `ModuleNotFoundError: No module named 'rapidocr'`.

---

### Additional Information

- Closes #26646
- The `rapidocr` project is the maintained successor to `rapidocr-onnxruntime`; it exposes the same `RapidOCR` entry point that `langchain-community` now imports. Both packages depend on `opencv-python`, so no new opencv variant conflict is introduced. `onnxruntime` continues to be pinned separately and serves as `rapidocr`'s default inference backend.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWbu6fkznXmSayZJjwN4vT)_