### PR TITLE
fix: preserve system prompt across tool calls when memories are enabled

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2198,6 +2198,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             form_data['model'] = selected_model_id
             metadata['selected_model_id'] = selected_model_id
 
+    # Capture the model's default system prompt before apply_params_to_form_data
+    # pops 'params'. The provider layer applies it fresh from model_info.params,
+    # but the native tool-call loop runs with bypass_system_prompt=True and relies
+    # on metadata['system_prompt'] (built below) to carry it forward instead.
+    model_system_prompt = (form_data.get('params') or {}).get('system')
+
     form_data = apply_params_to_form_data(form_data, model)
     log.debug(f'form_data: {form_data}')
 
@@ -2792,13 +2798,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # than a snapshot that already has the RAG template baked in.
     system_message = get_system_message(form_data['messages'])
     system_content = get_content_from_message(system_message) if system_message else ''
-    model_system_prompt = await resolve_system_prompt(
-        (form_data.get('params') or {}).get('system'),
+    resolved_model_system_prompt = await resolve_system_prompt(
+        model_system_prompt,
         metadata,
         user,
     )
-    if model_system_prompt:
-        system_content = f'{model_system_prompt}\n{system_content}' if system_content else model_system_prompt
+    if resolved_model_system_prompt:
+        system_content = (
+            f'{resolved_model_system_prompt}\n{system_content}'
+            if system_content
+            else resolved_model_system_prompt
+        )
     metadata['system_prompt'] = system_content or None
     metadata['user_prompt'] = get_last_user_message(form_data['messages'])
     metadata['sources'] = sources[:] if sources else []


### PR DESCRIPTION
# Pull Request Checklist

Closes #26836

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — `Closes #26836`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Behavior reproduced and verified against a simulation of the capture/restore flow (see below).
- [x] **No Unchecked AI Code:** Reviewed and reasoned through end-to-end.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; repairs existing intended behavior.
- [x] **Git Hygiene:** Atomic single-commit change.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

When the memory feature is enabled and the model triggers a native tool call (e.g. web search with citations, which injects the RAG template), the model's system prompt was dropped from every tool-call request. Only the injected `<memory_context>` remained in the system message. The very first and very last requests of a turn (which contain no tool calls) still had the full system prompt, which is what made the regression confusing to diagnose. This matches the report in #26836.

**Root cause**

The native tool-call loop calls `generate_chat_completion(..., bypass_system_prompt=True)`, so the provider layer (`routers/openai.py`, `routers/ollama.py`) does **not** re-apply the model's default system prompt on tool-call iterations. The loop relies instead on `metadata['system_prompt']` — snapshotted in `process_chat_payload` — to carry the full system prompt forward and restore it after RAG injection.

That snapshot built `model_system_prompt` from `form_data['params']['system']`, but `apply_params_to_form_data` had already **popped** `'params'` off `form_data` earlier in the same function. So `model_system_prompt` was always empty, and `metadata['system_prompt']` only captured whatever was already materialized in the messages:

- With memories enabled, that materialized content is the injected `<memory_context>` system message → tool-call requests were restored with memory-only system content, dropping the model system prompt.
- With memories disabled, there was no system message to capture at all, so the same loss could occur silently.

**Fix**

Capture the model's default system prompt from `form_data['params']` **before** `apply_params_to_form_data` pops it, and use that captured value when building `metadata['system_prompt']`. The restore path in the tool-call loop then re-installs the complete system prompt (model default + any chat-controls prompt + memory context), and `bypass_system_prompt=True` prevents double-application at the provider.

### Fixed

- System prompt no longer dropped from native tool-call requests (web search / RAG injection) when the memory feature is enabled.

---

### Additional Information

- This is a **separate** root cause from #26713 (context-compaction system-prompt loss). That fix lives in `utils/context_compaction.py`; this one is in `utils/middleware.py` and is unrelated to compaction (the reporter confirmed compaction was not in use).
- Verified by simulating the capture + tool-loop restore flow: before the change the restored tool-call system message contained only the memory context; after the change it contains the model system prompt followed by the memory context.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4L51mvxDJCx1EDxP2vFN

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z4L51mvxDJCx1EDxP2vFN)_