### PR TITLE
fix: don't mutate caller's payload when resolving a pipe base model

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -203,6 +203,10 @@ async def generate_function_chat_completion(request, form_data, user, models: di
 
         return params
 
+    # Copy so the base-model substitution below doesn't leak into the caller's
+    # payload, which the tool-call continuation re-submits. Mirrors the routers.
+    form_data = {**form_data}
+
     model_id = form_data.get('model')
     model_info = await Models.get_model_by_id(model_id)
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #26900 (unregistered base models bypassed in workspace models).
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified the caller's payload is no longer mutated by the pipe path (see below).
- [x] **No Unchecked AI Code:** Reviewed and reasoned through end-to-end.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; removes an unintended side effect on a shared dict.
- [x] **Git Hygiene:** Atomic single-commit change, based on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

`generate_function_chat_completion` (the pipe/function model path) rewrote `form_data['model']` to the base model id **in place**. That dict is the same object `process_chat_response` later re-submits for the post-tool-call continuation (it is snapshotted at `middleware.py` `model_id = form_data.get('model', '')`), so the continuation was access-checked against the **base model** rather than the **user-facing preset** the request started from.

For a public workspace preset (clone) whose base is a private/unregistered pipe model, this produced a role-dependent, silently-swallowed failure:

- The **first** message is access-checked against the preset → passes for a non-admin.
- The pipe runs and emits a native tool call.
- The **continuation** is access-checked against the base id (now in the shared dict) → raises `Model not found` for the non-admin; the exception is swallowed by `except Exception: log.debug(e); break` in the tool-call loop, so the response just stops after the tool call.
- Admins skip the `user.role == "user"` check entirely, so they were unaffected.

This matches the "first message works, response aborts right after a tool call, admins unaffected" symptom.

The openai/ollama router paths never had this problem because they substitute the base model on a **copy** of the payload (`payload = {**form_data}`); only the pipe path mutated the caller's dict.

### Fixed

- The pipe path now operates on a shallow copy of `form_data`, so resolving the base model no longer leaks back into the caller's payload. The post-tool-call continuation is re-checked against the preset the user actually has access to, matching the behavior of the openai/ollama routers. The metadata pop is likewise now local to the pipe handler.

---

### Additional Information

- Root-cause context and the full symptom analysis are in #26900.
- This is a distinct concern from the access-control chain fix (which denies non-admins access to unregistered base models through a preset). That fix blocks the reported private-base setup at the *first* message; this change removes the shared-dict mutation so the continuation and the first message are always checked against the same (preset) model id under stable state.
- A separate, still-open follow-up worth its own PR: the tool-call continuation loop swallows any exception at `except Exception: log.debug(e); break`, which hides ordinary provider errors and makes them look like this bug. Surfacing those as an error event would improve diagnosability but is an error-UX change, kept out of this focused fix.

### Verification

Drove the real `generate_function_chat_completion` against a migrated DB with a workspace preset whose `base_model_id` points at a pipe model, and asserted the caller's dict is untouched after the call:

- Pre-fix: `form_data['model']` `preset-pipe` → `base-pipe-fn` (leaked), `metadata` popped from caller.
- Post-fix: `form_data['model']` stays `preset-pipe`, `metadata` retained. Test flips from FAIL to OK on the one-line change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018toPfJW1hMXAhokGaL43Ep)_