### PR TITLE
feat: add per-chunk idle timeout for streaming LLM calls

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -565,6 +565,17 @@ try:
 except (ValueError, TypeError):
     AIOHTTP_CLIENT_TIMEOUT = 300
 
+# Per-chunk IDLE timeout (aiohttp sock_read) for streaming LLM calls: abort a
+# stream that stops producing tokens for this many seconds. This is NOT a total
+# cap — an active stream of any length keeps resetting it; only a STALL trips it.
+# AIOHTTP_CLIENT_TIMEOUT stays the (long) whole-call dead-man backstop. Unset =
+# None = no idle cap (upstream default behavior).
+_aiohttp_stream_idle_raw = os.getenv('AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE', '')
+try:
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE = int(_aiohttp_stream_idle_raw) if _aiohttp_stream_idle_raw else None
+except (ValueError, TypeError):
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE = None
+
 
 # SSL verification for general outbound requests (OpenAI, OAuth, etc.).
 # Accepts "True", "False", or a path to a CA bundle file.

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -26,6 +26,7 @@ from open_webui.events import EVENTS, publish_event, publish_model_provider_requ
 from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE,
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
     BYPASS_MODEL_ACCESS_CONTROL,
     ENABLE_FORWARD_USER_INFO_HEADERS,
@@ -1262,7 +1263,7 @@ async def generate_chat_completion(
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE),
         )
 
         # Check if response is SSE
@@ -1413,7 +1414,7 @@ async def embeddings(request: Request, form_data: dict, user):
             data=body,
             headers=headers,
             cookies=cookies,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE),
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
         )
 
@@ -1539,7 +1540,7 @@ async def responses(
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE),
         )
 
         # Check if response is SSE
@@ -1660,7 +1661,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE),
         )
 
         # Check if response is SSE

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5026,7 +5026,28 @@ async def streaming_chat_response_handler(response, ctx):
                         else:
                             break
                     except Exception as e:
-                        log.debug(e)
+                        # A failed/stalled continuation call (e.g. sock_read/stream
+                        # timeout after a tool result) must NOT be swallowed — a bare
+                        # break leaves the turn ending on tool calls with no visible
+                        # output (empty chat on refresh). Surface it like the
+                        # tool-iteration-limit path so the user sees a failure.
+                        log.exception('Tool-call continuation failed: %s', e)
+                        error_content = f'Generation failed after tool execution: {e}'
+                        if not metadata.get('chat_id', '').startswith('channel:'):
+                            try:
+                                await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                    metadata['chat_id'],
+                                    metadata['message_id'],
+                                    {'error': {'content': error_content}},
+                                )
+                            except Exception:
+                                pass
+                        await event_emitter(
+                            {
+                                'type': 'chat:message:error',
+                                'data': {'error': {'content': error_content}},
+                            }
+                        )
                         break
 
                 if (

--- a/backend/test/test_aiohttp_stream_idle_timeout.py
+++ b/backend/test/test_aiohttp_stream_idle_timeout.py
@@ -1,0 +1,136 @@
+"""Behavioral tests for the streaming per-chunk idle timeout.
+
+These guard the contract that ``AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE`` relies on:
+the streaming OpenAI-compatible calls in ``routers/openai.py`` build their
+timeout as ``aiohttp.ClientTimeout(total=..., sock_read=STREAM_IDLE)``. The
+``sock_read`` leg must abort a stream that *stalls* mid-response while leaving
+an *actively producing* stream (of any length) untouched, and must be a no-op
+when unset (``None``) so the default behavior is unchanged.
+
+The tests are self-contained (only ``aiohttp`` + ``pytest``) and do not import
+the full application, so they run without the backend's heavy dependency set.
+"""
+
+import asyncio
+
+import aiohttp
+from aiohttp import web
+from aiohttp.test_utils import unused_port
+
+# How long the stall handler hangs after its first chunk. It only needs to
+# outlast the longest client timeout used against it (total=2s in the unset
+# test) — kept short so ``runner.cleanup()`` doesn't block draining a handler
+# that is still sleeping.
+_STALL_SECONDS = 3
+
+
+async def _stall_handler(request):
+    """Emit one chunk, then hang — simulates a stalled upstream."""
+    resp = web.StreamResponse()
+    resp.headers['Content-Type'] = 'text/event-stream'
+    await resp.prepare(request)
+    await resp.write(b'data: chunk-0\n\n')
+    await asyncio.sleep(_STALL_SECONDS)
+    return resp
+
+
+async def _steady_handler(request):
+    """Emit 8 chunks 0.5s apart — active stream, never idle longer than 0.5s."""
+    resp = web.StreamResponse()
+    resp.headers['Content-Type'] = 'text/event-stream'
+    await resp.prepare(request)
+    for i in range(8):
+        await resp.write(f'data: chunk-{i}\n\n'.encode())
+        await asyncio.sleep(0.5)
+    await resp.write_eof()
+    return resp
+
+
+async def _serve():
+    port = unused_port()
+    app = web.Application()
+    app.add_routes(
+        [
+            web.get('/stall', _stall_handler),
+            web.get('/steady', _steady_handler),
+        ]
+    )
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', port)
+    await site.start()
+    return runner, f'http://127.0.0.1:{port}'
+
+
+async def _run_stall_trips_on_idle():
+    runner, base = await _serve()
+    try:
+        # total is a long dead-man backstop; sock_read is the short idle cap.
+        timeout = aiohttp.ClientTimeout(total=10, sock_read=1)
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        got_first_chunk = False
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f'{base}/stall', timeout=timeout) as resp:
+                async for _ in resp.content:
+                    got_first_chunk = True
+        return None, loop.time() - start, got_first_chunk
+    except asyncio.TimeoutError:
+        return 'timeout', loop.time() - start, got_first_chunk
+    finally:
+        await runner.cleanup()
+
+
+async def _run_steady_completes():
+    runner, base = await _serve()
+    try:
+        timeout = aiohttp.ClientTimeout(total=10, sock_read=1)
+        chunks = 0
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f'{base}/steady', timeout=timeout) as resp:
+                async for line in resp.content:
+                    if line.strip():
+                        chunks += 1
+        return chunks
+    finally:
+        await runner.cleanup()
+
+
+async def _run_unset_ignores_idle():
+    runner, base = await _serve()
+    try:
+        # sock_read=None (the unset default): idle must NOT trip; only total does.
+        timeout = aiohttp.ClientTimeout(total=2, sock_read=None)
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f'{base}/stall', timeout=timeout) as resp:
+                async for _ in resp.content:
+                    pass
+        return None, loop.time() - start
+    except asyncio.TimeoutError:
+        return 'timeout', loop.time() - start
+    finally:
+        await runner.cleanup()
+
+
+def test_stalled_stream_trips_sock_read_before_total():
+    kind, elapsed, got_first_chunk = asyncio.run(_run_stall_trips_on_idle())
+    assert kind == 'timeout'
+    # Tripped by the 1s idle cap, nowhere near the 30s total backstop.
+    assert 0.8 <= elapsed <= 5.0, elapsed
+    # The first chunk still arrives before the stall — only the gap trips.
+    assert got_first_chunk is True
+
+
+def test_active_stream_is_not_interrupted_by_idle_cap():
+    chunks = asyncio.run(_run_steady_completes())
+    # All 8 chunks delivered: idle gaps (0.5s) never exceed sock_read (1s).
+    assert chunks == 8
+
+
+def test_unset_sock_read_does_not_trip_on_idle():
+    kind, elapsed = asyncio.run(_run_unset_ignores_idle())
+    # With sock_read=None the stall is only bounded by total (2s), not idle.
+    assert kind == 'timeout'
+    assert elapsed >= 1.8, elapsed


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [x] **Testing:** Modified modules import/compile cleanly; behavior is opt-in and defaults to the existing behavior when unset.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults preferred — the idle timeout is unset by default, preserving current behavior.
- [x] **Git Hygiene:** The PR is atomic and rebased on `dev`.
- [x] **Title Prefix:** Uses the `feat` prefix.

# Changelog Entry

### Description

- Streaming LLM calls are currently governed only by `AIOHTTP_CLIENT_TIMEOUT`, a single whole-call timeout. Operators must choose between a value long enough to allow legitimately long generations (which lets a *stalled* upstream hang for that entire duration) and a value short enough to reap stalls (which prematurely kills long-but-healthy streams). This PR adds a separate per-chunk idle timeout so a stream that stops producing tokens can be aborted quickly without capping healthy long-running generations.
- Additionally, a failed or stalled tool-call continuation in the streaming response handler was silently swallowed by a bare `break`, leaving the turn ending on tool calls with no visible output (an empty chat on refresh). It is now surfaced as an error.

### Added

- `AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE` environment variable — an optional aiohttp `sock_read` (per-chunk idle) timeout in seconds, applied to the streaming OpenAI-compatible calls (chat completions, embeddings, responses, and the generic proxy). It bounds the gap *between* chunks: an actively producing stream of any length keeps resetting the timer, while a stall trips it. `AIOHTTP_CLIENT_TIMEOUT` remains the whole-call dead-man backstop. Unset = no idle cap (unchanged upstream behavior).

### Changed

- The four streaming aiohttp requests in `routers/openai.py` now pass `sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE` alongside the existing `total` timeout.

### Fixed

- A failed/stalled tool-call continuation in the streaming response handler is now recorded on the chat message and emitted as a `chat:message:error` event, instead of being silently dropped (which produced an empty chat on refresh).

---

### Additional Information

- Files changed: `backend/open_webui/env.py`, `backend/open_webui/routers/openai.py`, `backend/open_webui/utils/middleware.py`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNK3mqVE28375TT6w15qbJ)_