### PR TITLE
fix: retain the recent-messages window across turns after context compaction

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -108,7 +108,16 @@ async def compact_messages_for_request(
         raise
 
     chat_id = metadata.get('chat_id')
-    checkpoint_message_id = metadata.get('user_message_id') or metadata.get('message_id')
+    # The checkpoint marks where the retained recent window BEGINS, not where the
+    # current turn ends. Reconstruction (_apply_latest_summary_checkpoint) keeps
+    # messages from the marker forward, so the marker must sit on the first
+    # retained message; marking the current user message instead drops the whole
+    # retained window on every turn after the one that produced the summary.
+    checkpoint_message_id = (
+        _retained_checkpoint_message_id(recent_messages)
+        or metadata.get('user_message_id')
+        or metadata.get('message_id')
+    )
     if chat_id and checkpoint_message_id and not chat_id.startswith(('local:', 'channel:')):
         await Chats.upsert_message_to_chat_by_id_and_message_id(
             chat_id,
@@ -209,6 +218,21 @@ def _parse_positive_int(value: Any) -> int | None:
 def _resolve_token_threshold(global_threshold: int, global_cap: int, metadata: dict) -> int:
     configured_threshold = _parse_positive_int((metadata.get('params') or {}).get('compact_token_threshold'))
     return min(configured_threshold or global_threshold, global_cap)
+
+
+def _retained_checkpoint_message_id(recent_messages: list[dict]) -> str | None:
+    """Return the id of the first retained message that carries one.
+
+    The summary replaces everything before the retained window, so its
+    checkpoint belongs on the window's FIRST message. We scan forward for the
+    earliest message with a real id in case a leading synthetic entry (e.g. an
+    injected regeneration prompt) has none.
+    """
+    for message in recent_messages:
+        message_id = message.get('id')
+        if isinstance(message_id, str) and message_id:
+            return message_id
+    return None
 
 
 def _apply_latest_summary_checkpoint(messages: list[dict]) -> tuple[list[dict], str | None]:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1975,8 +1975,10 @@ async def load_messages_from_db(chat_id: str, message_id: str) -> Optional[list[
     if not db_messages:
         return None
 
+    # 'id' is kept as an internal handle so context compaction can anchor its
+    # summary checkpoint to a specific message; it is stripped before the LLM.
     return [
-        {k: v for k, v in msg.items() if k in ('role', 'content', 'output', 'files', 'contextSummary')}
+        {k: v for k, v in msg.items() if k in ('id', 'role', 'content', 'output', 'files', 'contextSummary')}
         for msg in db_messages
     ]
 
@@ -2035,6 +2037,9 @@ def strip_compaction_fields(messages: list[dict]) -> list[dict]:
         clean = dict(message)
         clean.pop('contextSummary', None)
         clean.pop('context_summary', None)
+        # Internal reconstruction handle from load_messages_from_db; providers
+        # must never see it.
+        clean.pop('id', None)
         stripped.append(clean)
     return stripped
 
@@ -2223,7 +2228,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         {
                             k: v
                             for k, v in assistant_message.items()
-                            if k in ('role', 'content', 'output', 'files', 'contextSummary')
+                            if k in ('id', 'role', 'content', 'output', 'files', 'contextSummary')
                         }
                     )
 

--- a/backend/test/test_context_compaction_retained_window.py
+++ b/backend/test/test_context_compaction_retained_window.py
@@ -1,0 +1,88 @@
+"""Regression tests for context-compaction retained-window persistence.
+
+Bug: the summary checkpoint was stored on the *current* (last) user message,
+i.e. the END of the retained recent window. Reconstruction
+(``_apply_latest_summary_checkpoint``) keeps messages from the marker forward,
+so on the compaction turn it worked, but on every later turn the retained ~40%
+window that sat *before* the marker was sliced away — leaving only
+``summary + current_user_message`` and breaking both caching and continuity.
+
+Fix: anchor the checkpoint to the FIRST retained message
+(``_retained_checkpoint_message_id``) so the whole window survives
+reconstruction on subsequent turns.
+
+These import the real functions, so they exercise the shipped logic. They need
+the backend dependency set installed (the normal dev/test environment).
+"""
+
+from open_webui.utils.context_compaction import (
+    _apply_latest_summary_checkpoint,
+    _find_compaction_boundary,
+    _retained_checkpoint_message_id,
+)
+
+
+def _make_chain():
+    chain = [{'id': f'm{i}', 'role': 'assistant' if i % 2 == 0 else 'user', 'content': f'msg{i}'} for i in range(1, 10)]
+    chain.append({'id': 'uA', 'role': 'user', 'content': 'current prompt A'})
+    return chain
+
+
+def _rebuild_turn2(chain, checkpoint_id, summary='SUMMARY'):
+    """The next-turn DB chain: same messages (marked at checkpoint) + a new exchange."""
+    rebuilt = [dict(message) for message in chain]
+    for message in rebuilt:
+        if message['id'] == checkpoint_id:
+            message['contextSummary'] = summary
+    rebuilt.append({'id': 'aA', 'role': 'assistant', 'content': 'answer A'})
+    rebuilt.append({'id': 'uB', 'role': 'user', 'content': 'prompt B'})
+    return rebuilt
+
+
+def test_retained_checkpoint_is_first_message_with_id():
+    recent = [
+        {'role': 'user', 'content': 'no id here'},  # synthetic (e.g. regeneration prompt)
+        {'id': 'm7', 'role': 'user', 'content': 'first real'},
+        {'id': 'm8', 'role': 'assistant', 'content': 'second real'},
+    ]
+    assert _retained_checkpoint_message_id(recent) == 'm7'
+
+
+def test_retained_checkpoint_none_when_no_ids():
+    assert _retained_checkpoint_message_id([{'role': 'user', 'content': 'x'}]) is None
+    assert _retained_checkpoint_message_id([]) is None
+
+
+def test_retained_window_survives_next_turn_with_fixed_checkpoint():
+    chain = _make_chain()
+    boundary = _find_compaction_boundary(chain)
+    recent = chain[boundary:]
+    assert len(recent) >= 2  # more than just the current user message
+
+    checkpoint_id = _retained_checkpoint_message_id(recent)
+    assert checkpoint_id == recent[0]['id']
+
+    reconstructed, summary = _apply_latest_summary_checkpoint(_rebuild_turn2(chain, checkpoint_id))
+    reconstructed_ids = [m['id'] for m in reconstructed]
+
+    # The entire retained window is preserved, and reconstruction begins at it.
+    assert reconstructed_ids[0] == recent[0]['id']
+    assert all(m['id'] in reconstructed_ids for m in recent)
+    assert summary == 'SUMMARY'
+
+
+def test_old_checkpoint_on_last_message_would_drop_the_window():
+    """Guard the regression: marking the current (last) message loses the window."""
+    chain = _make_chain()
+    boundary = _find_compaction_boundary(chain)
+    recent = chain[boundary:]
+
+    # Old behavior stored the summary on the current user message (chain[-1]).
+    reconstructed, _ = _apply_latest_summary_checkpoint(_rebuild_turn2(chain, chain[-1]['id']))
+    reconstructed_ids = [m['id'] for m in reconstructed]
+
+    # Only the current message + the new exchange survive — the retained window
+    # before it is gone. This is exactly what the fix prevents.
+    assert reconstructed_ids == ['uA', 'aA', 'uB']
+    dropped = [m['id'] for m in recent[:-1]]
+    assert dropped and all(mid not in reconstructed_ids for mid in dropped)


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** targets `dev`.
- [x] **Description:** provided below.
- [x] **Changelog:** included below.
- [x] **Testing:** static checks (ruff format + `F` lint, py_compile) pass; fix validated against the real reconstruction functions in a two-turn simulation.
- [x] **Self-Review:** performed.
- [x] **Git Hygiene:** atomic, rebased on `dev`.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

Context compaction is meant to send `summary + retained recent messages` on **every** turn after a compaction. In practice it only did so on the turn that produced the summary.

The checkpoint marking where the summary applies was stored on the **current (last) user message** — i.e. the *end* of the retained window — but reconstruction (`_apply_latest_summary_checkpoint`) keeps messages *from the marker forward*. So on the compaction turn it worked (the retained window is returned directly), but on every **subsequent** turn everything before the marker (the retained ~40% window) was sliced away, leaving just `summary + current user message`.

Impact, as reported in the issue:
- **Breaks prompt caching** — the message prefix changes shape every turn.
- **Breaks continuity** — the model loses the recent conversational context that the summary is explicitly instructed *not* to convey (it only summarizes the compacted block).

### Changed

- Anchor the summary checkpoint to the **first retained message** (`_retained_checkpoint_message_id`) instead of the current user message, so the whole retained window survives reconstruction on later turns.
- Thread the message `id` through `load_messages_from_db` as an internal handle (needed to anchor the checkpoint), and strip it in `strip_compaction_fields` before the payload reaches any provider.

### Fixed

- The retained recent-messages window is now sent alongside the summary on all turns following a compaction, restoring cache stability and recent-context continuity.

---

### Additional Information

- Files changed: `backend/open_webui/utils/context_compaction.py`, `backend/open_webui/utils/middleware.py`.
- No frontend changes: the checkpoint marker is a backend-only reconstruction handle (no `contextSummary` usage exists in the frontend).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)