### PR TITLE
fix: deterministic skill order in the available_skills manifest

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2606,7 +2606,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         from open_webui.models.skills import Skills as SkillsModel
 
         accessible_skill_ids = {s.id for s in await SkillsModel.get_skills_by_user_id(user.id, 'read')}
-        for sid in skill_ids:
+        # sorted: set order varies per process and byte-shuffles the prompt, breaking prompt caching
+        for sid in sorted(skill_ids):
             if sid in accessible_skill_ids:
                 s = await SkillsModel.get_skill_by_id(sid)
                 if s and s.is_active:


### PR DESCRIPTION
skill_ids is a set union and set iteration order varies across worker processes (string hash randomization), so on multi-worker or multi-replica installs the <available_skills> block in the system prompt shuffles between requests. That changes the system prompt bytes every turn and silently breaks provider prompt caching for the entire prefix (system prompt, tool definitions and history), so every request pays a full cache write and never gets a cache read. Sort the ids before building the manifest so the prompt is byte-stable across turns and replicas.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
